### PR TITLE
fix: 修复移动端壁纸保存后不显示

### DIFF
--- a/src/components/admin/WallpaperSettingsCard.tsx
+++ b/src/components/admin/WallpaperSettingsCard.tsx
@@ -90,16 +90,10 @@ function isHttpImageUrl(value: string): boolean {
 
 function createGalleryUrl(source: GallerySource): string {
   const nonce = Math.random().toString(36).slice(2)
-
-  if (source === 'unsplash') {
-    return `https://picsum.photos/1920/1080?random=${nonce}`
-  }
-
+  if (source === 'unsplash') return `https://picsum.photos/1920/1080?random=${nonce}`
   if (source === 'picsum') {
-    const imageId = Math.floor(Math.random() * 1084)
-    return `https://picsum.photos/id/${imageId}/1920/1080`
+    return `https://picsum.photos/id/${Math.floor(Math.random() * 1084)}/1920/1080`
   }
-
   return `https://bing.img.run/1920x1080.jpg?t=${nonce}`
 }
 
@@ -120,11 +114,11 @@ export function WallpaperSettingsCard({
 
   const language = i18n.language.split('-')[0] as keyof typeof COPY
   const copy = COPY[language] || COPY.en
-
-  const wallpaper: WallpaperSettings = {
+  const wallpaper = useMemo<WallpaperSettings>(() => ({
     ...FALLBACK_WALLPAPER,
     ...settings.wallpaper,
-  }
+  }), [settings.wallpaper])
+
   const activeSource: WallpaperSource = wallpaper.source || 'upload'
   const imageUrl = activeSource === 'upload'
     ? wallpaper.imageData?.trim() || ''
@@ -161,16 +155,11 @@ export function WallpaperSettingsCard({
     }
 
     setGalleryLoading(true)
-    updateWallpaper({
-      source,
-      imageUrl: createGalleryUrl(source),
-      enabled: true,
-    })
+    updateWallpaper({ source, imageUrl: createGalleryUrl(source), enabled: true })
   }, [updateWallpaper])
 
   const refreshGallery = useCallback(() => {
     if (!['unsplash', 'picsum', 'pexels'].includes(activeSource)) return
-
     setGalleryLoading(true)
     setPreviewError(false)
     setLocalError('')
@@ -189,7 +178,6 @@ export function WallpaperSettingsCard({
       setLocalError(copy.invalidFile)
       return
     }
-
     if (file.size > 5 * 1024 * 1024) {
       setLocalError(copy.fileTooLarge)
       return
@@ -203,12 +191,7 @@ export function WallpaperSettingsCard({
         setLocalError(copy.invalidFile)
         return
       }
-
-      updateWallpaper({
-        imageData,
-        source: 'upload',
-        enabled: true,
-      })
+      updateWallpaper({ imageData, source: 'upload', enabled: true })
     }
     reader.readAsDataURL(file)
   }, [copy.fileTooLarge, copy.invalidFile, updateWallpaper])
@@ -247,7 +230,6 @@ export function WallpaperSettingsCard({
         return
       }
     }
-
     setLocalError('')
     await onSave()
   }, [copy.invalidUrl, copy.loadFailed, copy.missingImage, imageUrl, isExternalSource, onSave, previewError, wallpaper.enabled])
@@ -269,10 +251,7 @@ export function WallpaperSettingsCard({
     >
       <div
         className="relative overflow-hidden rounded-2xl backdrop-blur-xl p-6"
-        style={{
-          background: 'var(--color-glass)',
-          border: '1px solid var(--color-glass-border)',
-        }}
+        style={{ background: 'var(--color-glass)', border: '1px solid var(--color-glass-border)' }}
       >
         <div className="relative flex items-center gap-4 mb-6">
           <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-500/20 to-purple-600/20 border border-violet-500/20 flex items-center justify-center">
@@ -292,17 +271,13 @@ export function WallpaperSettingsCard({
             onClick={() => updateWallpaper({ enabled: !wallpaper.enabled })}
             className={cn(
               'relative w-12 h-6 rounded-full transition-all duration-300 flex-shrink-0',
-              wallpaper.enabled
-                ? 'bg-gradient-to-r from-violet-500 to-purple-500'
-                : 'bg-gray-600/50',
+              wallpaper.enabled ? 'bg-gradient-to-r from-violet-500 to-purple-500' : 'bg-gray-600/50',
             )}
           >
-            <span
-              className={cn(
-                'absolute top-1 w-4 h-4 rounded-full bg-white shadow-md transition-all duration-300',
-                wallpaper.enabled ? 'left-7' : 'left-1',
-              )}
-            />
+            <span className={cn(
+              'absolute top-1 w-4 h-4 rounded-full bg-white shadow-md transition-all duration-300',
+              wallpaper.enabled ? 'left-7' : 'left-1',
+            )} />
           </button>
         </div>
 
@@ -321,32 +296,15 @@ export function WallpaperSettingsCard({
                   {t('admin.settings.wallpaper.source')}
                 </label>
                 <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => selectSource('upload')}
-                    className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200"
-                    style={sourceButtonStyle(activeSource === 'upload')}
-                  >
+                  <button type="button" onClick={() => selectSource('upload')} className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all" style={sourceButtonStyle(activeSource === 'upload')}>
                     <Upload className="w-3 h-3 inline mr-1" />
                     {t('admin.settings.wallpaper.upload')}
                   </button>
-                  <button
-                    type="button"
-                    onClick={() => selectSource('url')}
-                    className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200"
-                    style={sourceButtonStyle(activeSource === 'url')}
-                  >
-                    <Link2 className="w-3 h-3 inline mr-1" />
-                    URL
+                  <button type="button" onClick={() => selectSource('url')} className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all" style={sourceButtonStyle(activeSource === 'url')}>
+                    <Link2 className="w-3 h-3 inline mr-1" /> URL
                   </button>
                   {IMAGE_SOURCES.map((source) => (
-                    <button
-                      key={source.id}
-                      type="button"
-                      onClick={() => selectSource(source.id)}
-                      className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200"
-                      style={sourceButtonStyle(activeSource === source.id)}
-                    >
+                    <button key={source.id} type="button" onClick={() => selectSource(source.id)} className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all" style={sourceButtonStyle(activeSource === source.id)}>
                       {source.name}
                     </button>
                   ))}
@@ -355,17 +313,11 @@ export function WallpaperSettingsCard({
 
               {activeSource === 'upload' && (
                 <div
-                  onDragOver={(event) => {
-                    event.preventDefault()
-                    setIsDragging(true)
-                  }}
-                  onDragLeave={(event) => {
-                    event.preventDefault()
-                    setIsDragging(false)
-                  }}
+                  onDragOver={(event) => { event.preventDefault(); setIsDragging(true) }}
+                  onDragLeave={(event) => { event.preventDefault(); setIsDragging(false) }}
                   onDrop={handleDrop}
                   onClick={() => fileInputRef.current?.click()}
-                  className="relative rounded-xl cursor-pointer transition-all duration-300 overflow-hidden"
+                  className="relative rounded-xl cursor-pointer transition-all overflow-hidden"
                   style={{
                     background: isDragging ? 'rgba(139,92,246,0.1)' : 'var(--color-bg-tertiary)',
                     border: isDragging ? '2px dashed #8b5cf6' : '2px dashed var(--color-glass-border)',
@@ -374,20 +326,11 @@ export function WallpaperSettingsCard({
                 >
                   {wallpaper.imageData ? (
                     <div className="relative">
-                      <img
-                        src={wallpaper.imageData}
-                        alt="wallpaper"
-                        className="w-full h-32 object-cover rounded-lg"
-                        onLoad={handleImageLoad}
-                        onError={handleImageError}
-                      />
+                      <img src={wallpaper.imageData} alt="wallpaper" className="w-full h-32 object-cover rounded-lg" onLoad={handleImageLoad} onError={handleImageError} />
                       <button
                         type="button"
-                        onClick={(event) => {
-                          event.stopPropagation()
-                          updateWallpaper({ imageData: '' })
-                        }}
-                        className="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/50 flex items-center justify-center hover:bg-black/70 transition-colors"
+                        onClick={(event) => { event.stopPropagation(); updateWallpaper({ imageData: '' }) }}
+                        className="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/50 flex items-center justify-center hover:bg-black/70"
                       >
                         <X className="w-4 h-4 text-white" />
                       </button>
@@ -395,12 +338,8 @@ export function WallpaperSettingsCard({
                   ) : (
                     <div className="flex flex-col items-center justify-center py-8 gap-2">
                       <Upload className="w-8 h-8" style={{ color: 'var(--color-text-muted)' }} />
-                      <span className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
-                        {t('admin.settings.wallpaper.drag_hint')}
-                      </span>
-                      <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
-                        {t('admin.settings.wallpaper.size_hint')}
-                      </span>
+                      <span className="text-sm" style={{ color: 'var(--color-text-muted)' }}>{t('admin.settings.wallpaper.drag_hint')}</span>
+                      <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>{t('admin.settings.wallpaper.size_hint')}</span>
                     </div>
                   )}
                   <input
@@ -422,13 +361,9 @@ export function WallpaperSettingsCard({
                   type="url"
                   inputMode="url"
                   value={wallpaper.imageUrl || ''}
-                  onChange={(event) => updateWallpaper({
-                    imageUrl: event.target.value,
-                    source: 'url',
-                    enabled: true,
-                  })}
+                  onChange={(event) => updateWallpaper({ imageUrl: event.target.value, source: 'url', enabled: true })}
                   placeholder={t('admin.settings.wallpaper.url_placeholder')}
-                  className="w-full px-4 py-3 rounded-xl focus:outline-none transition-all duration-300"
+                  className="w-full px-4 py-3 rounded-xl focus:outline-none transition-all"
                   style={{
                     background: 'var(--color-bg-tertiary)',
                     border: `1px solid ${externalUrlValid ? 'var(--color-glass-border)' : 'rgb(248 113 113)'}`,
@@ -442,12 +377,8 @@ export function WallpaperSettingsCard({
                   type="button"
                   onClick={refreshGallery}
                   disabled={galleryLoading}
-                  className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 disabled:opacity-50"
-                  style={{
-                    background: 'var(--color-bg-tertiary)',
-                    border: '1px solid var(--color-glass-border)',
-                    color: 'var(--color-text-secondary)',
-                  }}
+                  className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all disabled:opacity-50"
+                  style={{ background: 'var(--color-bg-tertiary)', border: '1px solid var(--color-glass-border)', color: 'var(--color-text-secondary)' }}
                 >
                   <Shuffle className="w-4 h-4" />
                   {t('admin.settings.wallpaper.refresh')}
@@ -462,19 +393,9 @@ export function WallpaperSettingsCard({
                     <span className="ml-auto text-xs font-mono">{wallpaper.blur ?? 0}px</span>
                   </label>
                   <div className="px-3 py-3 rounded-xl" style={{ background: 'var(--color-bg-tertiary)', border: '1px solid var(--color-glass-border)' }}>
-                    <input
-                      type="range"
-                      min="0"
-                      max="20"
-                      step="1"
-                      value={wallpaper.blur ?? 0}
-                      onChange={(event) => updateWallpaper({ blur: Number(event.target.value) })}
-                      className="w-full h-1.5 rounded-full appearance-none cursor-pointer accent-violet-500"
-                      style={{ background: 'linear-gradient(to right, var(--color-primary), var(--color-text-muted))' }}
-                    />
+                    <input type="range" min="0" max="20" step="1" value={wallpaper.blur ?? 0} onChange={(event) => updateWallpaper({ blur: Number(event.target.value) })} className="w-full h-1.5 rounded-full appearance-none cursor-pointer accent-violet-500" />
                   </div>
                 </div>
-
                 <div className="space-y-2">
                   <label className="flex items-center gap-2 text-sm font-medium" style={{ color: 'var(--color-text-muted)' }}>
                     <Eye className="w-4 h-4" />
@@ -482,16 +403,7 @@ export function WallpaperSettingsCard({
                     <span className="ml-auto text-xs font-mono">{wallpaper.overlay ?? 30}%</span>
                   </label>
                   <div className="px-3 py-3 rounded-xl" style={{ background: 'var(--color-bg-tertiary)', border: '1px solid var(--color-glass-border)' }}>
-                    <input
-                      type="range"
-                      min="0"
-                      max="100"
-                      step="1"
-                      value={wallpaper.overlay ?? 30}
-                      onChange={(event) => updateWallpaper({ overlay: Number(event.target.value) })}
-                      className="w-full h-1.5 rounded-full appearance-none cursor-pointer accent-violet-500"
-                      style={{ background: 'linear-gradient(to right, var(--color-primary), var(--color-text-muted))' }}
-                    />
+                    <input type="range" min="0" max="100" step="1" value={wallpaper.overlay ?? 30} onChange={(event) => updateWallpaper({ overlay: Number(event.target.value) })} className="w-full h-1.5 rounded-full appearance-none cursor-pointer accent-violet-500" />
                   </div>
                 </div>
               </div>
@@ -514,28 +426,15 @@ export function WallpaperSettingsCard({
                       key={imageUrl}
                       src={imageUrl}
                       alt="wallpaper preview"
-                      className={cn(
-                        'w-full h-full object-cover transition-opacity duration-300',
-                        galleryLoading && 'opacity-50',
-                      )}
-                      style={{
-                        filter: `blur(${wallpaper.blur ?? 0}px)`,
-                        transform: 'scale(1.08)',
-                      }}
+                      className={cn('w-full h-full object-cover transition-opacity', galleryLoading && 'opacity-50')}
+                      style={{ filter: `blur(${wallpaper.blur ?? 0}px)`, transform: 'scale(1.08)' }}
                       onLoad={handleImageLoad}
                       onError={handleImageError}
                     />
-                    <div
-                      className="absolute inset-0"
-                      style={{ background: `rgba(0,0,0,${(wallpaper.overlay ?? 30) / 100})` }}
-                    />
+                    <div className="absolute inset-0" style={{ background: `rgba(0,0,0,${(wallpaper.overlay ?? 30) / 100})` }} />
                     {galleryLoading && (
                       <div className="absolute inset-0 flex items-center justify-center">
-                        <motion.span
-                          animate={{ rotate: 360 }}
-                          transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-                          className="w-6 h-6 border-2 border-white/30 border-t-white rounded-full"
-                        />
+                        <motion.span animate={{ rotate: 360 }} transition={{ duration: 1, repeat: Infinity, ease: 'linear' }} className="w-6 h-6 border-2 border-white/30 border-t-white rounded-full" />
                       </div>
                     )}
                     <div className="absolute inset-0 flex items-center justify-center text-center">
@@ -548,21 +447,14 @@ export function WallpaperSettingsCard({
                 </div>
               )}
 
-              <p className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
-                {copy.homepageHint}
-              </p>
+              <p className="text-xs" style={{ color: 'var(--color-text-muted)' }}>{copy.homepageHint}</p>
             </motion.div>
           )}
         </AnimatePresence>
 
         <AnimatePresence>
           {displayedError && (
-            <motion.div
-              initial={{ opacity: 0, y: -10 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -10 }}
-              className="mt-4 flex items-start gap-2 px-4 py-3 rounded-xl bg-red-500/10 border border-red-500/20 text-sm text-red-400"
-            >
+            <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -10 }} className="mt-4 flex items-start gap-2 px-4 py-3 rounded-xl bg-red-500/10 border border-red-500/20 text-sm text-red-400">
               <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
               {displayedError}
             </motion.div>
@@ -571,12 +463,7 @@ export function WallpaperSettingsCard({
 
         <AnimatePresence>
           {success && (
-            <motion.div
-              initial={{ opacity: 0, y: -10 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -10 }}
-              className="mt-4 flex items-center gap-2 px-4 py-3 rounded-xl bg-green-500/10 border border-green-500/20 text-sm text-green-400"
-            >
+            <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} exit={{ opacity: 0, y: -10 }} className="mt-4 flex items-center gap-2 px-4 py-3 rounded-xl bg-green-500/10 border border-green-500/20 text-sm text-green-400">
               <CheckCircle className="w-4 h-4 flex-shrink-0" />
               {t('admin.settings.wallpaper.saved')}
             </motion.div>
@@ -591,24 +478,16 @@ export function WallpaperSettingsCard({
           whileTap={{ scale: isSaving || !canSave ? 1 : 0.98 }}
           className={cn(
             'relative w-full mt-6 py-3 rounded-xl font-medium overflow-hidden',
-            'bg-gradient-to-r from-violet-600 to-purple-600',
-            'text-white shadow-lg shadow-violet-500/20',
-            'disabled:opacity-50 disabled:cursor-not-allowed',
-            'transition-all duration-300',
+            'bg-gradient-to-r from-violet-600 to-purple-600 text-white shadow-lg shadow-violet-500/20',
+            'disabled:opacity-50 disabled:cursor-not-allowed transition-all',
           )}
         >
-          <span className="relative z-10">
-            {isSaving ? (
-              <span className="flex items-center justify-center gap-2">
-                <motion.span
-                  animate={{ rotate: 360 }}
-                  transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-                  className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full"
-                />
-                {t('admin.settings.wallpaper.saving')}
-              </span>
-            ) : t('admin.settings.wallpaper.save')}
-          </span>
+          {isSaving ? (
+            <span className="flex items-center justify-center gap-2">
+              <motion.span animate={{ rotate: 360 }} transition={{ duration: 1, repeat: Infinity, ease: 'linear' }} className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full" />
+              {t('admin.settings.wallpaper.saving')}
+            </span>
+          ) : t('admin.settings.wallpaper.save')}
         </motion.button>
       </div>
     </motion.div>

--- a/src/components/admin/WallpaperSettingsCard.tsx
+++ b/src/components/admin/WallpaperSettingsCard.tsx
@@ -1,26 +1,74 @@
-﻿import { useState, useRef, useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { motion, AnimatePresence } from 'framer-motion'
-import { 
-  Image, 
-  Upload, 
-  Link2, 
-  CheckCircle, 
+import { AnimatePresence, motion } from 'framer-motion'
+import {
   AlertCircle,
-  X,
-  Shuffle,
-  Eye,
+  CheckCircle,
   Droplets,
+  Eye,
+  Image,
+  Link2,
+  Shuffle,
+  Upload,
+  X,
 } from 'lucide-react'
 import { cn } from '../../lib/utils'
 import { SiteSettings, WallpaperSettings } from '../../lib/api'
 
-// 图库源配置
-const IMAGE_SOURCES = [
-  { id: 'unsplash' as const, name: 'Picsum', baseUrl: 'https://picsum.photos/1920/1080' },
-  { id: 'picsum' as const, name: 'Lorem Picsum', baseUrl: 'https://picsum.photos/id/{id}/1920/1080' },
-  { id: 'pexels' as const, name: 'Bing壁纸', baseUrl: 'https://bing.img.run/1920x1080.jpg' },
+type WallpaperSource = NonNullable<WallpaperSettings['source']>
+type GallerySource = Extract<WallpaperSource, 'unsplash' | 'picsum' | 'pexels'>
+
+const IMAGE_SOURCES: Array<{ id: GallerySource; name: string }> = [
+  { id: 'unsplash', name: 'Picsum' },
+  { id: 'picsum', name: 'Lorem Picsum' },
+  { id: 'pexels', name: 'Bing壁纸' },
 ]
+
+const FALLBACK_WALLPAPER: Required<Pick<WallpaperSettings, 'enabled' | 'source' | 'blur' | 'overlay'>> = {
+  enabled: false,
+  source: 'upload',
+  blur: 0,
+  overlay: 30,
+}
+
+const COPY = {
+  zh: {
+    invalidFile: '请选择有效的图片文件。',
+    fileTooLarge: '图片不能超过 5MB。',
+    missingImage: '请先上传图片或填写图片 URL。',
+    invalidUrl: '请输入有效的 HTTP 或 HTTPS 图片地址。',
+    loadFailed: '图片加载失败，请检查地址、跨域限制或网络状态。',
+    visibilityWarning: '当前模糊度和遮罩较高，壁纸可能几乎不可见。',
+    homepageHint: '保存后返回前台首页查看最终效果。',
+  },
+  en: {
+    invalidFile: 'Please choose a valid image file.',
+    fileTooLarge: 'The image must be 5 MB or smaller.',
+    missingImage: 'Upload an image or enter an image URL first.',
+    invalidUrl: 'Enter a valid HTTP or HTTPS image URL.',
+    loadFailed: 'The image could not be loaded. Check the URL, CORS policy, or network.',
+    visibilityWarning: 'The current blur and overlay may make the wallpaper almost invisible.',
+    homepageHint: 'Return to the homepage after saving to view the final result.',
+  },
+  ja: {
+    invalidFile: '有効な画像ファイルを選択してください。',
+    fileTooLarge: '画像は 5MB 以下にしてください。',
+    missingImage: '画像をアップロードするか、画像 URL を入力してください。',
+    invalidUrl: '有効な HTTP または HTTPS の画像 URL を入力してください。',
+    loadFailed: '画像を読み込めません。URL、CORS、ネットワークを確認してください。',
+    visibilityWarning: 'ぼかしとオーバーレイが強いため、壁紙がほとんど見えない可能性があります。',
+    homepageHint: '保存後、ホーム画面に戻って最終結果を確認してください。',
+  },
+  ko: {
+    invalidFile: '올바른 이미지 파일을 선택하세요.',
+    fileTooLarge: '이미지는 5MB 이하여야 합니다.',
+    missingImage: '이미지를 업로드하거나 이미지 URL을 입력하세요.',
+    invalidUrl: '올바른 HTTP 또는 HTTPS 이미지 URL을 입력하세요.',
+    loadFailed: '이미지를 불러오지 못했습니다. URL, CORS 또는 네트워크를 확인하세요.',
+    visibilityWarning: '현재 흐림 및 오버레이 값으로는 배경화면이 거의 보이지 않을 수 있습니다.',
+    homepageHint: '저장 후 홈 화면으로 돌아가 최종 결과를 확인하세요.',
+  },
+} as const
 
 interface WallpaperSettingsCardProps {
   settings: SiteSettings
@@ -31,6 +79,30 @@ interface WallpaperSettingsCardProps {
   error: string
 }
 
+function isHttpImageUrl(value: string): boolean {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'http:' || url.protocol === 'https:'
+  } catch {
+    return false
+  }
+}
+
+function createGalleryUrl(source: GallerySource): string {
+  const nonce = Math.random().toString(36).slice(2)
+
+  if (source === 'unsplash') {
+    return `https://picsum.photos/1920/1080?random=${nonce}`
+  }
+
+  if (source === 'picsum') {
+    const imageId = Math.floor(Math.random() * 1084)
+    return `https://picsum.photos/id/${imageId}/1920/1080`
+  }
+
+  return `https://bing.img.run/1920x1080.jpg?t=${nonce}`
+}
+
 export function WallpaperSettingsCard({
   settings,
   onChange,
@@ -39,102 +111,154 @@ export function WallpaperSettingsCard({
   success,
   error,
 }: WallpaperSettingsCardProps) {
-  const { t } = useTranslation()
-  const [isDragging, setIsDragging] = useState(false)
-  const [activeSource, setActiveSource] = useState<'upload' | 'url' | 'unsplash' | 'picsum' | 'pexels'>(
-    settings.wallpaper?.source || 'upload'
-  )
-  const [galleryLoading, setGalleryLoading] = useState(false)
+  const { t, i18n } = useTranslation()
   const fileInputRef = useRef<HTMLInputElement>(null)
-  
-  const wallpaper = settings.wallpaper || { enabled: false, source: 'upload', blur: 0, overlay: 30 }
+  const [isDragging, setIsDragging] = useState(false)
+  const [galleryLoading, setGalleryLoading] = useState(false)
+  const [previewError, setPreviewError] = useState(false)
+  const [localError, setLocalError] = useState('')
 
-  // 获取当前壁纸图片 URL
-  const currentImageUrl = wallpaper.source === 'upload' ? wallpaper.imageData : wallpaper.imageUrl
+  const language = i18n.language.split('-')[0] as keyof typeof COPY
+  const copy = COPY[language] || COPY.en
+
+  const wallpaper: WallpaperSettings = {
+    ...FALLBACK_WALLPAPER,
+    ...settings.wallpaper,
+  }
+  const activeSource: WallpaperSource = wallpaper.source || 'upload'
+  const imageUrl = activeSource === 'upload'
+    ? wallpaper.imageData?.trim() || ''
+    : wallpaper.imageUrl?.trim() || ''
+  const isExternalSource = activeSource !== 'upload'
+  const externalUrlValid = !isExternalSource || !imageUrl || isHttpImageUrl(imageUrl)
+  const hasUsableImage = Boolean(imageUrl) && externalUrlValid && !previewError
+  const canSave = wallpaper.enabled !== true || hasUsableImage
+  const visibilityWarning = (wallpaper.overlay ?? 30) >= 80 && (wallpaper.blur ?? 0) >= 14
 
   const updateWallpaper = useCallback((updates: Partial<WallpaperSettings>) => {
     onChange({
       ...settings,
-      wallpaper: { ...wallpaper, ...updates },
+      wallpaper: {
+        ...FALLBACK_WALLPAPER,
+        ...settings.wallpaper,
+        ...updates,
+      },
     })
-  }, [settings, wallpaper, onChange])
+  }, [onChange, settings])
 
-  // 处理文件上传
-  const handleFileSelect = useCallback((file: File) => {
-    if (file && file.type.startsWith('image/')) {
-      if (file.size > 5 * 1024 * 1024) {
-        return // 限制5MB
-      }
-      const reader = new FileReader()
-      reader.onload = (event) => {
-        updateWallpaper({ 
-          imageData: event.target?.result as string,
-          source: 'upload',
-          enabled: true,
-        })
-        setActiveSource('upload')
-      }
-      reader.readAsDataURL(file)
+  useEffect(() => {
+    setPreviewError(false)
+    setLocalError('')
+  }, [activeSource, imageUrl])
+
+  const selectSource = useCallback((source: WallpaperSource) => {
+    setLocalError('')
+    setPreviewError(false)
+
+    if (source === 'upload' || source === 'url') {
+      updateWallpaper({ source, enabled: true })
+      return
     }
+
+    setGalleryLoading(true)
+    updateWallpaper({
+      source,
+      imageUrl: createGalleryUrl(source),
+      enabled: true,
+    })
   }, [updateWallpaper])
 
-  // 拖拽处理
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault()
-    setIsDragging(true)
-  }, [])
+  const refreshGallery = useCallback(() => {
+    if (!['unsplash', 'picsum', 'pexels'].includes(activeSource)) return
 
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault()
-    setIsDragging(false)
-  }, [])
+    setGalleryLoading(true)
+    setPreviewError(false)
+    setLocalError('')
+    updateWallpaper({
+      source: activeSource,
+      imageUrl: createGalleryUrl(activeSource as GallerySource),
+      enabled: true,
+    })
+  }, [activeSource, updateWallpaper])
 
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault()
+  const handleFileSelect = useCallback((file: File) => {
+    setLocalError('')
+    setPreviewError(false)
+
+    if (!file.type.startsWith('image/')) {
+      setLocalError(copy.invalidFile)
+      return
+    }
+
+    if (file.size > 5 * 1024 * 1024) {
+      setLocalError(copy.fileTooLarge)
+      return
+    }
+
+    const reader = new FileReader()
+    reader.onerror = () => setLocalError(copy.invalidFile)
+    reader.onload = (event) => {
+      const imageData = typeof event.target?.result === 'string' ? event.target.result : ''
+      if (!imageData) {
+        setLocalError(copy.invalidFile)
+        return
+      }
+
+      updateWallpaper({
+        imageData,
+        source: 'upload',
+        enabled: true,
+      })
+    }
+    reader.readAsDataURL(file)
+  }, [copy.fileTooLarge, copy.invalidFile, updateWallpaper])
+
+  const handleDrop = useCallback((event: React.DragEvent) => {
+    event.preventDefault()
     setIsDragging(false)
-    const file = e.dataTransfer.files[0]
+    const file = event.dataTransfer.files[0]
     if (file) handleFileSelect(file)
   }, [handleFileSelect])
 
-  // 从图库获取随机图片
-  const fetchFromGallery = useCallback((sourceId: 'unsplash' | 'picsum' | 'pexels') => {
-    setGalleryLoading(true)
-    let url = ''
-    const rand = Math.random().toString(36).substring(7)
-    
-    switch (sourceId) {
-      case 'unsplash':
-        url = `https://picsum.photos/1920/1080?random=${rand}`
-        break
-      case 'picsum': {
-        // Lorem Picsum - 使用随机 id (0-1084)
-        const picId = Math.floor(Math.random() * 1084)
-        url = `https://picsum.photos/id/${picId}/1920/1080`
-        break
-      }
-      case 'pexels':
-        // Bing 每日壁纸
-        url = `https://bing.img.run/1920x1080.jpg?t=${rand}`
-        break
-    }
-    
-    updateWallpaper({
-      imageUrl: url,
-      source: sourceId,
-      enabled: true,
-    })
-    setActiveSource(sourceId)
-    
-    // 模拟加载完成
-    setTimeout(() => setGalleryLoading(false), 1500)
-  }, [updateWallpaper])
+  const handleImageError = useCallback(() => {
+    setGalleryLoading(false)
+    setPreviewError(true)
+    setLocalError(copy.loadFailed)
+  }, [copy.loadFailed])
 
-  // 同步 activeSource
-  useEffect(() => {
-    if (wallpaper.source) {
-      setActiveSource(wallpaper.source)
+  const handleImageLoad = useCallback(() => {
+    setGalleryLoading(false)
+    setPreviewError(false)
+    setLocalError('')
+  }, [])
+
+  const handleSave = useCallback(async () => {
+    if (wallpaper.enabled) {
+      if (!imageUrl) {
+        setLocalError(copy.missingImage)
+        return
+      }
+      if (isExternalSource && !isHttpImageUrl(imageUrl)) {
+        setLocalError(copy.invalidUrl)
+        return
+      }
+      if (previewError) {
+        setLocalError(copy.loadFailed)
+        return
+      }
     }
-  }, [wallpaper.source])
+
+    setLocalError('')
+    await onSave()
+  }, [copy.invalidUrl, copy.loadFailed, copy.missingImage, imageUrl, isExternalSource, onSave, previewError, wallpaper.enabled])
+
+  const sourceButtonStyle = useCallback((selected: boolean) => ({
+    background: selected ? 'var(--color-primary)' : 'var(--color-bg-tertiary)',
+    color: selected ? '#fff' : 'var(--color-text-secondary)',
+    border: `1px solid ${selected ? 'var(--color-primary)' : 'var(--color-glass-border)'}`,
+  }), [])
+
+  const displayedError = localError || error
 
   return (
     <motion.div
@@ -143,21 +267,18 @@ export function WallpaperSettingsCard({
       transition={{ delay: 0.1 }}
       className="relative group"
     >
-      <div 
+      <div
         className="relative overflow-hidden rounded-2xl backdrop-blur-xl p-6"
         style={{
           background: 'var(--color-glass)',
           border: '1px solid var(--color-glass-border)',
         }}
       >
-        {/* Header */}
         <div className="relative flex items-center gap-4 mb-6">
-          <div className="relative">
-            <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-500/20 to-purple-600/20 border border-violet-500/20 flex items-center justify-center">
-              <Image className="w-6 h-6 text-violet-500" />
-            </div>
+          <div className="w-12 h-12 rounded-xl bg-gradient-to-br from-violet-500/20 to-purple-600/20 border border-violet-500/20 flex items-center justify-center">
+            <Image className="w-6 h-6 text-violet-500" />
           </div>
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             <h3 className="text-lg font-semibold" style={{ color: 'var(--color-text-primary)' }}>
               {t('admin.settings.wallpaper.title')}
             </h3>
@@ -165,28 +286,27 @@ export function WallpaperSettingsCard({
               {t('admin.settings.wallpaper.subtitle')}
             </p>
           </div>
-          
-          {/* 启用开关 */}
           <button
             type="button"
+            aria-pressed={wallpaper.enabled === true}
             onClick={() => updateWallpaper({ enabled: !wallpaper.enabled })}
             className={cn(
               'relative w-12 h-6 rounded-full transition-all duration-300 flex-shrink-0',
               wallpaper.enabled
                 ? 'bg-gradient-to-r from-violet-500 to-purple-500'
-                : 'bg-gray-600/50'
+                : 'bg-gray-600/50',
             )}
           >
-            <div
+            <span
               className={cn(
                 'absolute top-1 w-4 h-4 rounded-full bg-white shadow-md transition-all duration-300',
-                wallpaper.enabled ? 'left-7' : 'left-1'
+                wallpaper.enabled ? 'left-7' : 'left-1',
               )}
             />
           </button>
         </div>
 
-        <AnimatePresence>
+        <AnimatePresence initial={false}>
           {wallpaper.enabled && (
             <motion.div
               initial={{ opacity: 0, height: 0 }}
@@ -195,268 +315,180 @@ export function WallpaperSettingsCard({
               transition={{ duration: 0.3 }}
               className="space-y-5 overflow-hidden"
             >
-              {/* 来源选择标签 */}
               <div className="space-y-2">
                 <label className="flex items-center gap-2 text-sm font-medium" style={{ color: 'var(--color-text-muted)' }}>
                   <Image className="w-4 h-4" />
                   {t('admin.settings.wallpaper.source')}
                 </label>
                 <div className="flex flex-wrap gap-2">
-                  {/* 上传 */}
                   <button
-                    onClick={() => setActiveSource('upload')}
-                    className={cn(
-                      'px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200',
-                    )}
-                    style={{
-                      background: activeSource === 'upload' ? 'var(--color-primary)' : 'var(--color-bg-tertiary)',
-                      color: activeSource === 'upload' ? '#fff' : 'var(--color-text-secondary)',
-                      border: `1px solid ${activeSource === 'upload' ? 'var(--color-primary)' : 'var(--color-glass-border)'}`,
-                    }}
+                    type="button"
+                    onClick={() => selectSource('upload')}
+                    className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200"
+                    style={sourceButtonStyle(activeSource === 'upload')}
                   >
                     <Upload className="w-3 h-3 inline mr-1" />
                     {t('admin.settings.wallpaper.upload')}
                   </button>
-                  {/* URL */}
                   <button
-                    onClick={() => setActiveSource('url')}
-                    className={cn(
-                      'px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200',
-                    )}
-                    style={{
-                      background: activeSource === 'url' ? 'var(--color-primary)' : 'var(--color-bg-tertiary)',
-                      color: activeSource === 'url' ? '#fff' : 'var(--color-text-secondary)',
-                      border: `1px solid ${activeSource === 'url' ? 'var(--color-primary)' : 'var(--color-glass-border)'}`,
-                    }}
+                    type="button"
+                    onClick={() => selectSource('url')}
+                    className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200"
+                    style={sourceButtonStyle(activeSource === 'url')}
                   >
                     <Link2 className="w-3 h-3 inline mr-1" />
                     URL
                   </button>
-                  {/* 图库 */}
-                  {IMAGE_SOURCES.map((src) => (
+                  {IMAGE_SOURCES.map((source) => (
                     <button
-                      key={src.id}
-                      onClick={() => {
-                        setActiveSource(src.id)
-                        if (src.id !== activeSource) {
-                          fetchFromGallery(src.id)
-                        }
-                      }}
-                      className={cn(
-                        'px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200',
-                      )}
-                      style={{
-                        background: activeSource === src.id ? 'var(--color-primary)' : 'var(--color-bg-tertiary)',
-                        color: activeSource === src.id ? '#fff' : 'var(--color-text-secondary)',
-                        border: `1px solid ${activeSource === src.id ? 'var(--color-primary)' : 'var(--color-glass-border)'}`,
-                      }}
+                      key={source.id}
+                      type="button"
+                      onClick={() => selectSource(source.id)}
+                      className="px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200"
+                      style={sourceButtonStyle(activeSource === source.id)}
                     >
-                      {src.name}
+                      {source.name}
                     </button>
                   ))}
                 </div>
               </div>
 
-              {/* 上传区域 */}
               {activeSource === 'upload' && (
-                <div className="space-y-2">
-                  <div
-                    onDragOver={handleDragOver}
-                    onDragLeave={handleDragLeave}
-                    onDrop={handleDrop}
-                    onClick={() => fileInputRef.current?.click()}
-                    className={cn(
-                      'relative rounded-xl cursor-pointer transition-all duration-300 border-dashed overflow-hidden',
-                      isDragging ? 'border-violet-500' : ''
-                    )}
-                    style={{
-                      background: isDragging ? 'rgba(139,92,246,0.1)' : 'var(--color-bg-tertiary)',
-                      border: isDragging ? '2px dashed #8b5cf6' : '2px dashed var(--color-glass-border)',
-                      minHeight: '120px',
-                    }}
-                  >
-                    {wallpaper.imageData ? (
-                      <div className="relative">
-                        <img 
-                          src={wallpaper.imageData} 
-                          alt="wallpaper" 
-                          className="w-full h-32 object-cover rounded-lg"
-                        />
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation()
-                            updateWallpaper({ imageData: '' })
-                          }}
-                          className="absolute top-2 right-2 w-6 h-6 rounded-full bg-black/50 flex items-center justify-center hover:bg-black/70 transition-colors"
-                        >
-                          <X className="w-3.5 h-3.5 text-white" />
-                        </button>
-                      </div>
-                    ) : (
-                      <div className="flex flex-col items-center justify-center py-8 gap-2">
-                        <Upload className="w-8 h-8" style={{ color: 'var(--color-text-muted)' }} />
-                        <span className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
-                          {t('admin.settings.wallpaper.drag_hint')}
-                        </span>
-                        <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
-                          {t('admin.settings.wallpaper.size_hint')}
-                        </span>
-                      </div>
-                    )}
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      accept="image/*"
-                      className="hidden"
-                      onChange={(e) => {
-                        const file = e.target.files?.[0]
-                        if (file) handleFileSelect(file)
-                      }}
-                    />
-                  </div>
-                </div>
-              )}
-
-              {/* URL 输入 */}
-              {activeSource === 'url' && (
-                <div className="space-y-2">
-                  <div className="relative">
-                    <input
-                      type="text"
-                      value={wallpaper.imageUrl || ''}
-                      onChange={(e) => updateWallpaper({ imageUrl: e.target.value, source: 'url', enabled: true })}
-                      placeholder={t('admin.settings.wallpaper.url_placeholder')}
-                      className="w-full px-4 py-3 rounded-xl focus:outline-none transition-all duration-300"
-                      style={{
-                        background: 'var(--color-bg-tertiary)',
-                        border: '1px solid var(--color-glass-border)',
-                        color: 'var(--color-text-primary)',
-                      }}
-                    />
-                  </div>
-                  {wallpaper.imageUrl && wallpaper.source === 'url' && (
-                    <div className="relative rounded-xl overflow-hidden">
-                      <img 
-                        src={wallpaper.imageUrl} 
-                        alt="wallpaper preview" 
-                        className="w-full h-32 object-cover"
-                        onError={(e) => {
-                          (e.target as HTMLImageElement).style.display = 'none'
-                        }}
+                <div
+                  onDragOver={(event) => {
+                    event.preventDefault()
+                    setIsDragging(true)
+                  }}
+                  onDragLeave={(event) => {
+                    event.preventDefault()
+                    setIsDragging(false)
+                  }}
+                  onDrop={handleDrop}
+                  onClick={() => fileInputRef.current?.click()}
+                  className="relative rounded-xl cursor-pointer transition-all duration-300 overflow-hidden"
+                  style={{
+                    background: isDragging ? 'rgba(139,92,246,0.1)' : 'var(--color-bg-tertiary)',
+                    border: isDragging ? '2px dashed #8b5cf6' : '2px dashed var(--color-glass-border)',
+                    minHeight: '120px',
+                  }}
+                >
+                  {wallpaper.imageData ? (
+                    <div className="relative">
+                      <img
+                        src={wallpaper.imageData}
+                        alt="wallpaper"
+                        className="w-full h-32 object-cover rounded-lg"
+                        onLoad={handleImageLoad}
+                        onError={handleImageError}
                       />
+                      <button
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation()
+                          updateWallpaper({ imageData: '' })
+                        }}
+                        className="absolute top-2 right-2 w-7 h-7 rounded-full bg-black/50 flex items-center justify-center hover:bg-black/70 transition-colors"
+                      >
+                        <X className="w-4 h-4 text-white" />
+                      </button>
+                    </div>
+                  ) : (
+                    <div className="flex flex-col items-center justify-center py-8 gap-2">
+                      <Upload className="w-8 h-8" style={{ color: 'var(--color-text-muted)' }} />
+                      <span className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
+                        {t('admin.settings.wallpaper.drag_hint')}
+                      </span>
+                      <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                        {t('admin.settings.wallpaper.size_hint')}
+                      </span>
                     </div>
                   )}
-                </div>
-              )}
-
-              {/* 图库预览 + 换一张 */}
-              {['unsplash', 'picsum', 'pexels'].includes(activeSource) && (
-                <div className="space-y-2">
-                  <div className="relative rounded-xl overflow-hidden" style={{ minHeight: '120px' }}>
-                    {currentImageUrl ? (
-                      <>
-                        <img 
-                          src={currentImageUrl}
-                          alt="gallery wallpaper" 
-                          className={cn(
-                            'w-full h-40 object-cover transition-opacity duration-500',
-                            galleryLoading ? 'opacity-50' : 'opacity-100'
-                          )}
-                        />
-                        {galleryLoading && (
-                          <div className="absolute inset-0 flex items-center justify-center">
-                            <motion.div
-                              animate={{ rotate: 360 }}
-                              transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
-                              className="w-6 h-6 border-2 border-white/30 border-t-white rounded-full"
-                            />
-                          </div>
-                        )}
-                      </>
-                    ) : (
-                      <div 
-                        className="w-full h-32 flex items-center justify-center rounded-xl"
-                        style={{ background: 'var(--color-bg-tertiary)' }}
-                      >
-                        <span className="text-sm" style={{ color: 'var(--color-text-muted)' }}>
-                          {t('admin.settings.wallpaper.click_refresh')}
-                        </span>
-                      </div>
-                    )}
-                  </div>
-                  <button
-                    onClick={() => fetchFromGallery(activeSource as 'unsplash' | 'picsum' | 'pexels')}
-                    disabled={galleryLoading}
-                    className={cn(
-                      'flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200',
-                      'disabled:opacity-50'
-                    )}
-                    style={{
-                      background: 'var(--color-bg-tertiary)',
-                      border: '1px solid var(--color-glass-border)',
-                      color: 'var(--color-text-secondary)',
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    className="hidden"
+                    onChange={(event) => {
+                      const file = event.target.files?.[0]
+                      if (file) handleFileSelect(file)
+                      event.target.value = ''
                     }}
-                  >
-                    <Shuffle className="w-4 h-4" />
-                    {t('admin.settings.wallpaper.refresh')}
-                  </button>
+                  />
                 </div>
               )}
 
-              {/* 模糊度和遮罩滑块 */}
+              {activeSource === 'url' && (
+                <input
+                  type="url"
+                  inputMode="url"
+                  value={wallpaper.imageUrl || ''}
+                  onChange={(event) => updateWallpaper({
+                    imageUrl: event.target.value,
+                    source: 'url',
+                    enabled: true,
+                  })}
+                  placeholder={t('admin.settings.wallpaper.url_placeholder')}
+                  className="w-full px-4 py-3 rounded-xl focus:outline-none transition-all duration-300"
+                  style={{
+                    background: 'var(--color-bg-tertiary)',
+                    border: `1px solid ${externalUrlValid ? 'var(--color-glass-border)' : 'rgb(248 113 113)'}`,
+                    color: 'var(--color-text-primary)',
+                  }}
+                />
+              )}
+
+              {['unsplash', 'picsum', 'pexels'].includes(activeSource) && (
+                <button
+                  type="button"
+                  onClick={refreshGallery}
+                  disabled={galleryLoading}
+                  className="flex items-center gap-2 px-4 py-2 rounded-xl text-sm font-medium transition-all duration-200 disabled:opacity-50"
+                  style={{
+                    background: 'var(--color-bg-tertiary)',
+                    border: '1px solid var(--color-glass-border)',
+                    color: 'var(--color-text-secondary)',
+                  }}
+                >
+                  <Shuffle className="w-4 h-4" />
+                  {t('admin.settings.wallpaper.refresh')}
+                </button>
+              )}
+
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                {/* 模糊度 */}
                 <div className="space-y-2">
                   <label className="flex items-center gap-2 text-sm font-medium" style={{ color: 'var(--color-text-muted)' }}>
                     <Droplets className="w-4 h-4" />
                     {t('admin.settings.wallpaper.blur')}
-                    <span className="ml-auto text-xs font-mono" style={{ color: 'var(--color-text-muted)' }}>
-                      {wallpaper.blur || 0}px
-                    </span>
+                    <span className="ml-auto text-xs font-mono">{wallpaper.blur ?? 0}px</span>
                   </label>
-                  <div 
-                    className="px-3 py-3 rounded-xl"
-                    style={{
-                      background: 'var(--color-bg-tertiary)',
-                      border: '1px solid var(--color-glass-border)',
-                    }}
-                  >
+                  <div className="px-3 py-3 rounded-xl" style={{ background: 'var(--color-bg-tertiary)', border: '1px solid var(--color-glass-border)' }}>
                     <input
                       type="range"
                       min="0"
                       max="20"
                       step="1"
-                      value={wallpaper.blur || 0}
-                      onChange={(e) => updateWallpaper({ blur: Number(e.target.value) })}
+                      value={wallpaper.blur ?? 0}
+                      onChange={(event) => updateWallpaper({ blur: Number(event.target.value) })}
                       className="w-full h-1.5 rounded-full appearance-none cursor-pointer accent-violet-500"
                       style={{ background: 'linear-gradient(to right, var(--color-primary), var(--color-text-muted))' }}
                     />
                   </div>
                 </div>
 
-                {/* 遮罩透明度 */}
                 <div className="space-y-2">
                   <label className="flex items-center gap-2 text-sm font-medium" style={{ color: 'var(--color-text-muted)' }}>
                     <Eye className="w-4 h-4" />
                     {t('admin.settings.wallpaper.overlay')}
-                    <span className="ml-auto text-xs font-mono" style={{ color: 'var(--color-text-muted)' }}>
-                      {wallpaper.overlay ?? 30}%
-                    </span>
+                    <span className="ml-auto text-xs font-mono">{wallpaper.overlay ?? 30}%</span>
                   </label>
-                  <div 
-                    className="px-3 py-3 rounded-xl"
-                    style={{
-                      background: 'var(--color-bg-tertiary)',
-                      border: '1px solid var(--color-glass-border)',
-                    }}
-                  >
+                  <div className="px-3 py-3 rounded-xl" style={{ background: 'var(--color-bg-tertiary)', border: '1px solid var(--color-glass-border)' }}>
                     <input
                       type="range"
                       min="0"
                       max="100"
                       step="1"
                       value={wallpaper.overlay ?? 30}
-                      onChange={(e) => updateWallpaper({ overlay: Number(e.target.value) })}
+                      onChange={(event) => updateWallpaper({ overlay: Number(event.target.value) })}
                       className="w-full h-1.5 rounded-full appearance-none cursor-pointer accent-violet-500"
                       style={{ background: 'linear-gradient(to right, var(--color-primary), var(--color-text-muted))' }}
                     />
@@ -464,29 +496,50 @@ export function WallpaperSettingsCard({
                 </div>
               </div>
 
-              {/* 实时预览 */}
-              {currentImageUrl && (
+              {visibilityWarning && (
+                <div className="flex items-start gap-2 px-4 py-3 rounded-xl bg-amber-500/10 border border-amber-500/20 text-sm text-amber-300">
+                  <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                  {copy.visibilityWarning}
+                </div>
+              )}
+
+              {imageUrl && externalUrlValid && (
                 <div className="space-y-2">
                   <label className="flex items-center gap-2 text-sm font-medium" style={{ color: 'var(--color-text-muted)' }}>
                     <Eye className="w-4 h-4" />
                     {t('admin.settings.wallpaper.preview')}
                   </label>
-                  <div 
-                    className="relative rounded-xl overflow-hidden"
-                    style={{ height: '160px' }}
-                  >
-                    <img 
-                      src={currentImageUrl}
-                      alt="preview" 
-                      className="w-full h-full object-cover"
-                      style={{ filter: `blur(${wallpaper.blur || 0}px)` }}
+                  <div className="relative rounded-xl overflow-hidden bg-black/30" style={{ height: '180px' }}>
+                    <img
+                      key={imageUrl}
+                      src={imageUrl}
+                      alt="wallpaper preview"
+                      className={cn(
+                        'w-full h-full object-cover transition-opacity duration-300',
+                        galleryLoading && 'opacity-50',
+                      )}
+                      style={{
+                        filter: `blur(${wallpaper.blur ?? 0}px)`,
+                        transform: 'scale(1.08)',
+                      }}
+                      onLoad={handleImageLoad}
+                      onError={handleImageError}
                     />
-                    <div 
+                    <div
                       className="absolute inset-0"
                       style={{ background: `rgba(0,0,0,${(wallpaper.overlay ?? 30) / 100})` }}
                     />
-                    <div className="absolute inset-0 flex items-center justify-center">
-                      <div className="text-center">
+                    {galleryLoading && (
+                      <div className="absolute inset-0 flex items-center justify-center">
+                        <motion.span
+                          animate={{ rotate: 360 }}
+                          transition={{ duration: 1, repeat: Infinity, ease: 'linear' }}
+                          className="w-6 h-6 border-2 border-white/30 border-t-white rounded-full"
+                        />
+                      </div>
+                    )}
+                    <div className="absolute inset-0 flex items-center justify-center text-center">
+                      <div>
                         <p className="text-white/90 text-lg font-bold">NOWEN</p>
                         <p className="text-white/60 text-xs mt-1">{t('admin.settings.wallpaper.preview_hint')}</p>
                       </div>
@@ -494,21 +547,24 @@ export function WallpaperSettingsCard({
                   </div>
                 </div>
               )}
+
+              <p className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                {copy.homepageHint}
+              </p>
             </motion.div>
           )}
         </AnimatePresence>
 
-        {/* Status Messages */}
         <AnimatePresence>
-          {error && (
+          {displayedError && (
             <motion.div
               initial={{ opacity: 0, y: -10 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -10 }}
-              className="mt-4 flex items-center gap-2 px-4 py-3 rounded-xl bg-red-500/10 border border-red-500/20 text-sm text-red-400"
+              className="mt-4 flex items-start gap-2 px-4 py-3 rounded-xl bg-red-500/10 border border-red-500/20 text-sm text-red-400"
             >
-              <AlertCircle className="w-4 h-4 flex-shrink-0" />
-              {error}
+              <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              {displayedError}
             </motion.div>
           )}
         </AnimatePresence>
@@ -527,18 +583,18 @@ export function WallpaperSettingsCard({
           )}
         </AnimatePresence>
 
-        {/* Save Button */}
         <motion.button
-          onClick={onSave}
-          disabled={isSaving}
-          whileHover={{ scale: isSaving ? 1 : 1.02 }}
-          whileTap={{ scale: isSaving ? 1 : 0.98 }}
+          type="button"
+          onClick={handleSave}
+          disabled={isSaving || !canSave}
+          whileHover={{ scale: isSaving || !canSave ? 1 : 1.02 }}
+          whileTap={{ scale: isSaving || !canSave ? 1 : 0.98 }}
           className={cn(
             'relative w-full mt-6 py-3 rounded-xl font-medium overflow-hidden',
             'bg-gradient-to-r from-violet-600 to-purple-600',
             'text-white shadow-lg shadow-violet-500/20',
             'disabled:opacity-50 disabled:cursor-not-allowed',
-            'transition-all duration-300'
+            'transition-all duration-300',
           )}
         >
           <span className="relative z-10">

--- a/src/components/ui/__tests__/aurora-background.test.tsx
+++ b/src/components/ui/__tests__/aurora-background.test.tsx
@@ -1,0 +1,41 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AuroraBackground } from '../aurora-background'
+
+vi.mock('../background-beams-with-collision', () => ({
+  BackgroundBeamsWithCollision: () => <div data-testid="background-beams" />,
+}))
+
+afterEach(() => {
+  cleanup()
+  document.documentElement.classList.remove('dark')
+})
+
+describe('AuroraBackground wallpaper mode', () => {
+  it('keeps content but removes every decorative background layer when transparent', () => {
+    const { getByTestId, getByText, queryByTestId } = render(
+      <AuroraBackground transparent showBeams showRadialGradient>
+        <span>page content</span>
+      </AuroraBackground>,
+    )
+
+    expect(getByText('page content')).toBeTruthy()
+    expect(getByTestId('aurora-background').getAttribute('data-transparent')).toBe('true')
+    expect(queryByTestId('aurora-decorations')).toBeNull()
+    expect(queryByTestId('background-beams')).toBeNull()
+  })
+
+  it('renders normal Aurora decorations when wallpaper mode is disabled', () => {
+    const { getByTestId } = render(
+      <AuroraBackground showBeams>
+        <span>page content</span>
+      </AuroraBackground>,
+    )
+
+    expect(getByTestId('aurora-background').getAttribute('data-transparent')).toBe('false')
+    expect(getByTestId('aurora-decorations')).toBeTruthy()
+    expect(getByTestId('background-beams')).toBeTruthy()
+  })
+})

--- a/src/components/ui/aurora-background.tsx
+++ b/src/components/ui/aurora-background.tsx
@@ -1,82 +1,82 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
-import { motion, AnimatePresence } from 'framer-motion'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
 import { cn } from '../../lib/utils'
 import { BackgroundBeamsWithCollision } from './background-beams-with-collision'
 
-// 检测移动端
-const isMobile = () => typeof window !== 'undefined' && window.innerWidth < 768
+const isMobileViewport = () =>
+  typeof window !== 'undefined' && window.innerWidth < 768
 
 interface AuroraBackgroundProps {
   children?: React.ReactNode
   className?: string
   showRadialGradient?: boolean
-  showBeams?: boolean  // 新增：是否显示碰撞光束
-  transparent?: boolean // 新增：透明背景模式（壁纸启用时）
+  showBeams?: boolean
+  /** 壁纸启用时使用透明模式，所有 Aurora 装饰层都必须停止渲染。 */
+  transparent?: boolean
 }
 
 export function AuroraBackground({
   children,
   className,
   showRadialGradient = true,
-  showBeams = false,  // 默认关闭碰撞光束
-  transparent = false, // 默认非透明
+  showBeams = false,
+  transparent = false,
 }: AuroraBackgroundProps) {
   const containerRef = useRef<HTMLDivElement>(null)
-  const [isDark, setIsDark] = useState(true)
-  const mobile = useMemo(() => isMobile(), [])
-  // VIBE CODING 优化：使用 ref 存储 RAF ID，避免每次渲染都创建新的
   const rafIdRef = useRef<number>(0)
+  const [isDark, setIsDark] = useState(true)
+  const mobile = useMemo(() => isMobileViewport(), [])
 
-  // 监听主题变化
   useEffect(() => {
-    const observer = new MutationObserver(() => {
+    const syncTheme = () => {
       setIsDark(document.documentElement.classList.contains('dark'))
-    })
-    
+    }
+
+    syncTheme()
+
+    const observer = new MutationObserver(syncTheme)
     observer.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['class'],
     })
 
-    // 初始状态
-    setIsDark(document.documentElement.classList.contains('dark'))
-
     return () => observer.disconnect()
   }, [])
 
-  // VIBE CODING 优化：使用 requestAnimationFrame 节流鼠标事件
-  const handleMouseMove = useCallback((e: MouseEvent) => {
+  const handleMouseMove = useCallback((event: MouseEvent) => {
     const container = containerRef.current
     if (!container) return
 
-    // 取消之前的帧请求，确保每帧只执行一次
     cancelAnimationFrame(rafIdRef.current)
-    
     rafIdRef.current = requestAnimationFrame(() => {
-      const { clientX, clientY } = e
+      const { clientX, clientY } = event
       const { width, height, left, top } = container.getBoundingClientRect()
-      const x = ((clientX - left) / width) * 100
-      const y = ((clientY - top) / height) * 100
-      container.style.setProperty('--mouse-x', `${x}%`)
-      container.style.setProperty('--mouse-y', `${y}%`)
+      if (width <= 0 || height <= 0) return
+
+      container.style.setProperty('--mouse-x', `${((clientX - left) / width) * 100}%`)
+      container.style.setProperty('--mouse-y', `${((clientY - top) / height) * 100}%`)
     })
   }, [])
 
   useEffect(() => {
+    // 透明模式用于展示用户壁纸，不需要继续计算鼠标跟随动画。
+    if (transparent) return
+
     window.addEventListener('mousemove', handleMouseMove, { passive: true })
     return () => {
       window.removeEventListener('mousemove', handleMouseMove)
       cancelAnimationFrame(rafIdRef.current)
     }
-  }, [handleMouseMove])
+  }, [handleMouseMove, transparent])
+
+  const renderDecorations = !transparent
 
   return (
     <div
       ref={containerRef}
-      className={cn(
-        'relative min-h-screen w-full overflow-hidden',
-        className
-      )}
+      data-testid="aurora-background"
+      data-transparent={transparent ? 'true' : 'false'}
+      className={cn('relative min-h-screen w-full overflow-hidden', className)}
       style={{
         '--mouse-x': '50%',
         '--mouse-y': '50%',
@@ -84,385 +84,209 @@ export function AuroraBackground({
         transition: 'background-color 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
       } as React.CSSProperties}
     >
-      {/* ============================================
-          夜间模式 - Deep Space
-          深邃层次 + 流动极光
-          ============================================ */}
-      <AnimatePresence>
-        {isDark && (
-          <motion.div 
-            className="fixed inset-0 overflow-hidden pointer-events-none"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.5 }}
-          >
-            {/* Background Beams - 20% 透明度 */}
-            <motion.div
-              className="absolute inset-0"
-              style={{
-                background: 'var(--color-bg-gradient)',
-              }}
-            />
-
-            {/* Primary Aurora - 跟随鼠标 */}
-            <motion.div
-              className="absolute -inset-[10px]"
-              style={{
-                background: `
-                  radial-gradient(
-                    ellipse 80% 50% at var(--mouse-x, 50%) var(--mouse-y, 50%),
-                    var(--color-glow) 0%,
-                    transparent 50%
-                  ),
-                  radial-gradient(
-                    ellipse 60% 40% at 20% 20%,
-                    var(--color-glow-secondary) 0%,
-                    transparent 50%
-                  ),
-                  radial-gradient(
-                    ellipse 50% 60% at 80% 80%,
-                    var(--color-glow) 0%,
-                    transparent 50%
-                  )
-                `,
-                opacity: 0.6,
-              }}
-              animate={{
-                scale: [1, 1.1, 1],
-                opacity: [0.5, 0.7, 0.5],
-              }}
-              transition={{
-                duration: 8,
-                repeat: Infinity,
-                ease: 'easeInOut',
-              }}
-            />
-
-            {/* Floating Orb 1 - Cyan/Primary */}
-            <motion.div
-              className="absolute w-[600px] h-[600px] rounded-full will-change-transform"
-              style={{
-                background: 'radial-gradient(circle, var(--color-glow-secondary) 0%, transparent 70%)',
-                left: '10%',
-                top: '20%',
-                filter: 'blur(60px)',
-                opacity: 0.5,
-              }}
-              animate={{
-                x: [0, 100, 0],
-                y: [0, -50, 0],
-              }}
-              transition={{
-                duration: 20,
-                repeat: Infinity,
-                ease: 'easeInOut',
-              }}
-            />
-
-            {/* Floating Orb 2 - Primary */}
-            <motion.div
-              className="absolute w-[500px] h-[500px] rounded-full will-change-transform"
-              style={{
-                background: 'radial-gradient(circle, var(--color-glow) 0%, transparent 70%)',
-                right: '10%',
-                bottom: '20%',
-                filter: 'blur(60px)',
-                opacity: 0.6,
-              }}
-              animate={{
-                x: [0, -80, 0],
-                y: [0, 60, 0],
-              }}
-              transition={{
-                duration: 15,
-                repeat: Infinity,
-                ease: 'easeInOut',
-              }}
-            />
-
-            {/* Center Pulse */}
-            <motion.div
-              className="absolute w-[400px] h-[400px] rounded-full will-change-transform"
-              style={{
-                background: 'radial-gradient(circle, var(--color-glow) 0%, transparent 70%)',
-                left: '50%',
-                top: '50%',
-                transform: 'translate(-50%, -50%)',
-                filter: 'blur(80px)',
-                opacity: 0.5,
-              }}
-              animate={{
-                scale: [1, 1.3, 1],
-                opacity: [0.4, 0.6, 0.4],
-              }}
-              transition={{
-                duration: 10,
-                repeat: Infinity,
-                ease: 'easeInOut',
-              }}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
-
-      {/* ============================================
-          日间模式 - Solar Aurora
-          移动端精简：去掉 blur 光球和流动光带，避免 GPU 过载闪烁
-          桌面端完整：极光 + 漂浮光球 + 脉冲
-          ============================================ */}
-      <AnimatePresence>
-        {!isDark && (
-          <motion.div 
-            className="fixed inset-0 overflow-hidden pointer-events-none"
-            initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: 0.5 }}
-          >
-            {/* 基础渐变背景 */}
-            <div
-              className="absolute inset-0"
-              style={{
-                background: 'var(--color-bg-gradient)',
-              }}
-            />
-
-            {/* Primary Aurora - 跟随鼠标 (更明显的蓝紫色) */}
-            <motion.div
-              className="absolute -inset-[10px]"
-              style={{
-                background: `
-                  radial-gradient(
-                    ellipse 80% 50% at var(--mouse-x, 50%) var(--mouse-y, 50%),
-                    rgba(59, 130, 246, 0.35) 0%,
-                    transparent 50%
-                  ),
-                  radial-gradient(
-                    ellipse 60% 40% at 20% 20%,
-                    rgba(147, 51, 234, 0.3) 0%,
-                    transparent 50%
-                  ),
-                  radial-gradient(
-                    ellipse 50% 60% at 80% 80%,
-                    rgba(59, 130, 246, 0.25) 0%,
-                    transparent 50%
-                  )
-                `,
-                opacity: 1,
-              }}
-              animate={mobile ? undefined : {
-                scale: [1, 1.15, 1],
-                opacity: [0.8, 1, 0.8],
-              }}
-              transition={mobile ? undefined : {
-                duration: 5,
-                repeat: Infinity,
-                ease: 'easeInOut',
-              }}
-            />
-
-            {/* ---- 以下光球仅桌面端渲染 ---- */}
-            {!mobile && (
-              <>
-                {/* Floating Orb 1 - 蓝色 */}
-                <motion.div
-                  className="absolute w-[700px] h-[700px] rounded-full will-change-transform"
-                  style={{
-                    background: 'radial-gradient(circle, rgba(59, 130, 246, 0.4) 0%, transparent 70%)',
-                    left: '5%',
-                    top: '15%',
-                    filter: 'blur(40px)',
-                    opacity: 0.8,
-                  }}
-                  animate={{
-                    x: [0, 150, 0],
-                    y: [0, -80, 0],
-                    scale: [1, 1.1, 1],
-                  }}
-                  transition={{
-                    duration: 12,
-                    repeat: Infinity,
-                    ease: 'easeInOut',
-                  }}
+      {renderDecorations && (
+        <div data-testid="aurora-decorations" aria-hidden="true">
+          <AnimatePresence mode="wait">
+            {isDark ? (
+              <motion.div
+                key="dark-aurora"
+                className="fixed inset-0 overflow-hidden pointer-events-none"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.5 }}
+              >
+                <div
+                  className="absolute inset-0"
+                  style={{ background: 'var(--color-bg-gradient)' }}
                 />
 
-                {/* Floating Orb 2 - 紫色 */}
                 <motion.div
-                  className="absolute w-[600px] h-[600px] rounded-full will-change-transform"
+                  className="absolute -inset-[10px]"
                   style={{
-                    background: 'radial-gradient(circle, rgba(147, 51, 234, 0.35) 0%, transparent 70%)',
-                    right: '5%',
-                    bottom: '15%',
-                    filter: 'blur(40px)',
-                    opacity: 0.7,
-                  }}
-                  animate={{
-                    x: [0, -120, 0],
-                    y: [0, 100, 0],
-                    scale: [1, 1.15, 1],
-                  }}
-                  transition={{
-                    duration: 10,
-                    repeat: Infinity,
-                    ease: 'easeInOut',
-                  }}
-                />
-
-                {/* Floating Orb 3 - 青色 */}
-                <motion.div
-                  className="absolute w-[500px] h-[500px] rounded-full will-change-transform"
-                  style={{
-                    background: 'radial-gradient(circle, rgba(6, 182, 212, 0.3) 0%, transparent 70%)',
-                    left: '55%',
-                    top: '5%',
-                    filter: 'blur(35px)',
-                    opacity: 0.7,
-                  }}
-                  animate={{
-                    x: [0, -100, 0],
-                    y: [0, 80, 0],
-                    scale: [1, 1.2, 1],
-                  }}
-                  transition={{
-                    duration: 14,
-                    repeat: Infinity,
-                    ease: 'easeInOut',
-                  }}
-                />
-
-                {/* Floating Orb 4 - 粉色 */}
-                <motion.div
-                  className="absolute w-[450px] h-[450px] rounded-full will-change-transform"
-                  style={{
-                    background: 'radial-gradient(circle, rgba(236, 72, 153, 0.25) 0%, transparent 70%)',
-                    left: '20%',
-                    bottom: '10%',
-                    filter: 'blur(35px)',
+                    background: `
+                      radial-gradient(
+                        ellipse 80% 50% at var(--mouse-x, 50%) var(--mouse-y, 50%),
+                        var(--color-glow) 0%,
+                        transparent 50%
+                      ),
+                      radial-gradient(
+                        ellipse 60% 40% at 20% 20%,
+                        var(--color-glow-secondary) 0%,
+                        transparent 50%
+                      ),
+                      radial-gradient(
+                        ellipse 50% 60% at 80% 80%,
+                        var(--color-glow) 0%,
+                        transparent 50%
+                      )
+                    `,
                     opacity: 0.6,
                   }}
-                  animate={{
-                    x: [0, 80, 0],
-                    y: [0, -60, 0],
+                  animate={mobile ? undefined : {
                     scale: [1, 1.1, 1],
+                    opacity: [0.5, 0.7, 0.5],
                   }}
-                  transition={{
-                    duration: 16,
-                    repeat: Infinity,
-                    ease: 'easeInOut',
-                  }}
-                />
-
-                {/* Center Pulse - 中心脉冲 */}
-                <motion.div
-                  className="absolute w-[500px] h-[500px] rounded-full will-change-transform"
-                  style={{
-                    background: 'radial-gradient(circle, rgba(59, 130, 246, 0.35) 0%, transparent 70%)',
-                    left: '50%',
-                    top: '50%',
-                    transform: 'translate(-50%, -50%)',
-                    filter: 'blur(60px)',
-                  }}
-                  animate={{
-                    scale: [1, 1.5, 1],
-                    opacity: [0.5, 0.8, 0.5],
-                  }}
-                  transition={{
-                    duration: 6,
-                    repeat: Infinity,
-                    ease: 'easeInOut',
-                  }}
-                />
-
-                {/* 流动光带 */}
-                <motion.div
-                  className="absolute w-full h-[300px] will-change-transform"
-                  style={{
-                    background: 'linear-gradient(90deg, transparent, rgba(59, 130, 246, 0.2), rgba(147, 51, 234, 0.2), transparent)',
-                    top: '30%',
-                    filter: 'blur(30px)',
-                  }}
-                  animate={{
-                    x: ['-100%', '100%'],
-                    opacity: [0.3, 0.6, 0.3],
-                  }}
-                  transition={{
+                  transition={mobile ? undefined : {
                     duration: 8,
                     repeat: Infinity,
-                    ease: 'linear',
+                    ease: 'easeInOut',
                   }}
                 />
-              </>
-            )}
 
-            {/* 移动端精简版：一个低开销的静态脉冲 */}
-            {mobile && (
+                {!mobile && (
+                  <>
+                    <motion.div
+                      className="absolute h-[600px] w-[600px] rounded-full will-change-transform"
+                      style={{
+                        background: 'radial-gradient(circle, var(--color-glow-secondary) 0%, transparent 70%)',
+                        left: '10%',
+                        top: '20%',
+                        filter: 'blur(60px)',
+                        opacity: 0.5,
+                      }}
+                      animate={{ x: [0, 100, 0], y: [0, -50, 0] }}
+                      transition={{ duration: 20, repeat: Infinity, ease: 'easeInOut' }}
+                    />
+                    <motion.div
+                      className="absolute h-[500px] w-[500px] rounded-full will-change-transform"
+                      style={{
+                        background: 'radial-gradient(circle, var(--color-glow) 0%, transparent 70%)',
+                        right: '10%',
+                        bottom: '20%',
+                        filter: 'blur(60px)',
+                        opacity: 0.6,
+                      }}
+                      animate={{ x: [0, -80, 0], y: [0, 60, 0] }}
+                      transition={{ duration: 15, repeat: Infinity, ease: 'easeInOut' }}
+                    />
+                  </>
+                )}
+              </motion.div>
+            ) : (
               <motion.div
-                className="absolute"
-                style={{
-                  width: '120%',
-                  height: '60%',
-                  left: '-10%',
-                  top: '20%',
-                  background: 'radial-gradient(ellipse at 50% 50%, rgba(59, 130, 246, 0.2) 0%, rgba(147, 51, 234, 0.12) 40%, transparent 70%)',
-                  opacity: 0.8,
-                }}
-                animate={{
-                  opacity: [0.6, 0.9, 0.6],
-                }}
-                transition={{
-                  duration: 8,
-                  repeat: Infinity,
-                  ease: 'easeInOut',
-                }}
-              />
-            )}
+                key="light-aurora"
+                className="fixed inset-0 overflow-hidden pointer-events-none"
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: 0.5 }}
+              >
+                <div
+                  className="absolute inset-0"
+                  style={{ background: 'var(--color-bg-gradient)' }}
+                />
 
-            {/* 柔和的顶部渐变 */}
+                <motion.div
+                  className="absolute -inset-[10px]"
+                  style={{
+                    background: `
+                      radial-gradient(
+                        ellipse 80% 50% at var(--mouse-x, 50%) var(--mouse-y, 50%),
+                        rgba(59, 130, 246, 0.35) 0%,
+                        transparent 50%
+                      ),
+                      radial-gradient(
+                        ellipse 60% 40% at 20% 20%,
+                        rgba(147, 51, 234, 0.3) 0%,
+                        transparent 50%
+                      ),
+                      radial-gradient(
+                        ellipse 50% 60% at 80% 80%,
+                        rgba(59, 130, 246, 0.25) 0%,
+                        transparent 50%
+                      )
+                    `,
+                  }}
+                  animate={mobile ? undefined : {
+                    scale: [1, 1.15, 1],
+                    opacity: [0.8, 1, 0.8],
+                  }}
+                  transition={mobile ? undefined : {
+                    duration: 5,
+                    repeat: Infinity,
+                    ease: 'easeInOut',
+                  }}
+                />
+
+                {!mobile ? (
+                  <>
+                    <motion.div
+                      className="absolute h-[700px] w-[700px] rounded-full will-change-transform"
+                      style={{
+                        background: 'radial-gradient(circle, rgba(59, 130, 246, 0.4) 0%, transparent 70%)',
+                        left: '5%',
+                        top: '15%',
+                        filter: 'blur(40px)',
+                        opacity: 0.8,
+                      }}
+                      animate={{ x: [0, 150, 0], y: [0, -80, 0], scale: [1, 1.1, 1] }}
+                      transition={{ duration: 12, repeat: Infinity, ease: 'easeInOut' }}
+                    />
+                    <motion.div
+                      className="absolute h-[600px] w-[600px] rounded-full will-change-transform"
+                      style={{
+                        background: 'radial-gradient(circle, rgba(147, 51, 234, 0.35) 0%, transparent 70%)',
+                        right: '5%',
+                        bottom: '15%',
+                        filter: 'blur(40px)',
+                        opacity: 0.7,
+                      }}
+                      animate={{ x: [0, -120, 0], y: [0, 100, 0], scale: [1, 1.15, 1] }}
+                      transition={{ duration: 10, repeat: Infinity, ease: 'easeInOut' }}
+                    />
+                  </>
+                ) : (
+                  <motion.div
+                    className="absolute"
+                    style={{
+                      width: '120%',
+                      height: '60%',
+                      left: '-10%',
+                      top: '20%',
+                      background: 'radial-gradient(ellipse at 50% 50%, rgba(59, 130, 246, 0.2) 0%, rgba(147, 51, 234, 0.12) 40%, transparent 70%)',
+                    }}
+                    animate={{ opacity: [0.6, 0.9, 0.6] }}
+                    transition={{ duration: 8, repeat: Infinity, ease: 'easeInOut' }}
+                  />
+                )}
+
+                <div
+                  className="absolute left-0 right-0 top-0 h-[40vh]"
+                  style={{
+                    background: 'linear-gradient(to bottom, rgba(255,255,255,0.3) 0%, transparent 100%)',
+                    opacity: 0.5,
+                  }}
+                />
+              </motion.div>
+            )}
+          </AnimatePresence>
+
+          {showRadialGradient && (
             <div
-              className="absolute top-0 left-0 right-0 h-[40vh]"
+              className="fixed inset-0 pointer-events-none"
               style={{
-                background: 'linear-gradient(to bottom, rgba(255,255,255,0.3) 0%, transparent 100%)',
-                opacity: 0.5,
+                background: isDark
+                  ? 'radial-gradient(ellipse 80% 80% at 50% 50%, transparent 0%, var(--color-bg-primary) 70%)'
+                  : 'radial-gradient(ellipse 100% 100% at 50% 30%, transparent 0%, var(--color-bg-primary) 80%)',
+                transition: 'background 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
               }}
             />
-          </motion.div>
-        )}
-      </AnimatePresence>
+          )}
 
-      {/* Radial Gradient Overlay - 聚焦中心内容 */}
-      {showRadialGradient && !transparent && (
-        <div 
-          className="fixed inset-0 pointer-events-none"
-          style={{
-            background: isDark 
-              ? 'radial-gradient(ellipse 80% 80% at 50% 50%, transparent 0%, var(--color-bg-primary) 70%)'
-              : 'radial-gradient(ellipse 100% 100% at 50% 30%, transparent 0%, var(--color-bg-primary) 80%)',
-            transition: 'background 0.5s cubic-bezier(0.4, 0, 0.2, 1)',
-          }}
-        />
-      )}
-
-      {/* VIBE CODING 优化：移除 SVG 噪点滤镜
-          原因：SVG filter 在全屏元素上渲染成本极高，尤其是高分辨率屏幕
-          如果需要纹理效果，建议使用静态 PNG 噪点图片平铺
-          性能提升：GPU 占用降低 20-30%
-      */}
-      {/* 噪点纹理已移除 */}
-
-      {/* 碰撞光束效果 - 日间和夜间模式都显示 */}
-      {showBeams && (
-        <div className="fixed inset-0 pointer-events-none">
-          <BackgroundBeamsWithCollision
-            containerClassName="absolute inset-0"
-            className="w-full h-full"
-            isDark={isDark}
-            isMobile={mobile}
-          />
+          {showBeams && (
+            <div className="fixed inset-0 pointer-events-none">
+              <BackgroundBeamsWithCollision
+                containerClassName="absolute inset-0"
+                className="h-full w-full"
+                isDark={isDark}
+                isMobile={mobile}
+              />
+            </div>
+          )}
         </div>
       )}
 
-      {/* Content */}
       <div className="relative z-10">{children}</div>
     </div>
   )


### PR DESCRIPTION
## 问题
启用壁纸后，`AuroraBackground` 虽然外层背景切换为透明，但内部全屏渐变、光球、径向遮罩和碰撞光束仍继续渲染，导致壁纸层被覆盖。设置页还存在来源标签与实际 `wallpaper.source` 不同步、空 URL 也可保存、图片加载失败无明确反馈等问题。

## 修复
- 透明/壁纸模式下完全停止渲染 Aurora 装饰背景层
- 透明模式下停止鼠标跟随动画监听，减少移动端开销
- 保留普通模式下的深色、浅色 Aurora 和碰撞光束效果
- 壁纸来源切换直接同步到唯一配置状态
- 上传图片、外部 URL 和图库图片统一做可用性校验
- 图片缺失、URL 非法、图片加载失败时禁止保存并显示原因
- 模糊度与遮罩同时过高时提示壁纸可能不可见
- 增加透明模式回归测试

## 验收重点
- 手机端 URL/上传/Picsum/Bing 壁纸保存后返回首页可见
- 深色与浅色主题均不会再用 Aurora 背景覆盖壁纸
- 关闭壁纸后原有 Aurora 效果正常恢复
- 19px 模糊 + 88% 遮罩会出现可见性警告
