### PR TITLE
fix(ui): make night meteors smoother and less frequent

### DIFF
--- a/src/components/ui/effects.tsx
+++ b/src/components/ui/effects.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { motion } from 'framer-motion'
 import { cn } from '../../lib/utils'
 
@@ -6,28 +7,44 @@ interface MeteorsProps {
   className?: string
 }
 
-export function Meteors({ number = 20, className }: MeteorsProps) {
-  const meteors = Array.from({ length: number }, (_, i) => ({
-    id: i,
-    left: `${Math.random() * 100}%`,
-    animationDelay: `${Math.random() * 2}s`,
-    animationDuration: `${Math.random() * 8 + 5}s`,
-  }))
+const MAX_VISIBLE_METEORS = 6
+
+export function Meteors({ number = MAX_VISIBLE_METEORS, className }: MeteorsProps) {
+  const meteorCount = Math.max(0, Math.min(number, MAX_VISIBLE_METEORS))
+
+  // Keep each meteor's position and timing stable across parent re-renders.
+  // A long, staggered cycle keeps only one or two meteors visible at once.
+  const meteors = useMemo(
+    () =>
+      Array.from({ length: meteorCount }, (_, i) => ({
+        id: i,
+        left: `${35 + Math.random() * 75}%`,
+        top: `${Math.random() * 22}%`,
+        animationDelay: `${i * 2.2 + Math.random() * 1.2}s`,
+        animationDuration: `${12 + Math.random() * 3.5}s`,
+      })),
+    [meteorCount]
+  )
 
   return (
-    <div className={cn('absolute inset-0 overflow-hidden pointer-events-none', className)}>
+    <div
+      aria-hidden="true"
+      className={cn('absolute inset-0 overflow-hidden pointer-events-none', className)}
+    >
       {meteors.map((meteor) => (
         <span
           key={meteor.id}
-          className="absolute top-0 w-0.5 h-0.5 rounded-full bg-white rotate-[215deg] animate-meteor"
+          className="absolute w-0.5 h-0.5 rounded-full bg-white/80 animate-meteor motion-reduce:hidden"
           style={{
             left: meteor.left,
+            top: meteor.top,
             animationDelay: meteor.animationDelay,
             animationDuration: meteor.animationDuration,
+            willChange: 'transform, opacity',
           }}
         >
           {/* Tail */}
-          <span className="absolute top-1/2 -translate-y-1/2 w-[100px] h-[1px] bg-gradient-to-r from-white/50 to-transparent" />
+          <span className="absolute top-1/2 -translate-y-1/2 w-[120px] h-px bg-gradient-to-r from-white/40 via-white/20 to-transparent" />
         </span>
       ))}
     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -85,7 +85,7 @@ export default {
         'pulse-glow': 'pulse-glow 2s ease-in-out infinite',
         'spin-slow': 'spin 20s linear infinite',
         'spotlight': 'spotlight 2s ease .75s 1 forwards',
-        'meteor': 'meteor 5s linear infinite',
+        'meteor': 'meteor 13s linear infinite',
         'border-beam': 'border-beam var(--duration, 12s) linear infinite',
       },
       keyframes: {
@@ -122,9 +122,20 @@ export default {
           },
         },
         meteor: {
-          '0%': { transform: 'rotate(215deg) translateX(0)', opacity: 1 },
-          '70%': { opacity: 1 },
-          '100%': { transform: 'rotate(215deg) translateX(-500px)', opacity: 0 },
+          '0%, 3%': {
+            transform: 'rotate(215deg) translate3d(0, 0, 0)',
+            opacity: 0,
+          },
+          '6%': { opacity: 0.75 },
+          '26%': { opacity: 0.38 },
+          '34%': {
+            transform: 'rotate(215deg) translate3d(-560px, 0, 0)',
+            opacity: 0,
+          },
+          '100%': {
+            transform: 'rotate(215deg) translate3d(-560px, 0, 0)',
+            opacity: 0,
+          },
         },
         'border-beam': {
           '100%': { offsetDistance: '100%' },


### PR DESCRIPTION
## 问题

夜间模式流星数量较多，动画开始时直接显示，循环结束后又立即回到起点，造成频繁闪烁和不够丝滑的观感。

## 修复

- 将同时参与动画的流星上限收敛为 6 颗，避免首页原有 `number={15}` 导致画面过于密集
- 动画参数通过 `useMemo` 固定，父组件重新渲染时不再随机跳位或重置节奏
- 单次循环调整为约 12～15.5 秒，并按索引错峰 2.2 秒
- 增加完整的隐藏等待阶段，只在循环前约三分之一时间内划过
- 起点和终点均保持透明，消除循环重置时的闪回
- 使用 `translate3d` 与 `will-change` 提升浏览器合成流畅度
- 降低流星和尾迹亮度，尾迹略微延长，让移动更柔和
- 用户启用“减少动态效果”时隐藏流星动画

## 预期效果

夜间首页同屏通常只出现 1～2 颗流星，流星缓慢、错峰划过，不再集中闪烁或在右上角突然重置。