### PR TITLE
fix(ui): hide empty mobile bottom bar

### DIFF
--- a/src/components/ui/mobile-floating-dock.tsx
+++ b/src/components/ui/mobile-floating-dock.tsx
@@ -96,6 +96,7 @@ export function MobileFloatingDock({
 
   // 当前要渲染的列表：子菜单状态下用 subItems，否则用主 items
   const displayItems = activeSubmenu?.subItems ?? items;
+  const hasLeftSlot = Boolean(leftSlot);
 
   return (
     <>
@@ -244,26 +245,25 @@ export function MobileFloatingDock({
         )}
       </AnimatePresence>
 
-      {/* 底部固定栏 */}
+      {/* 有状态内容时展示完整底栏；无状态内容时只保留右下角菜单按钮 */}
       <div
         className={cn(
-          "fixed bottom-0 left-0 right-0 z-[75]",
-          "flex items-center px-3 py-2",
-          "bg-white/90 dark:bg-black/80",
-          "backdrop-blur-xl",
-          "border-t border-slate-200/60 dark:border-white/10",
-          "safe-area-bottom",
+          "fixed z-[75] flex items-center",
+          hasLeftSlot &&
+            "bottom-0 left-0 right-0 px-3 py-2 bg-white/90 dark:bg-black/80 backdrop-blur-xl border-t border-slate-200/60 dark:border-white/10 safe-area-bottom",
+          !hasLeftSlot && "right-3",
           className
         )}
-        style={{ paddingBottom: "max(8px, env(safe-area-inset-bottom))" }}
+        style={
+          hasLeftSlot
+            ? { paddingBottom: "max(8px, env(safe-area-inset-bottom))" }
+            : { bottom: "max(8px, env(safe-area-inset-bottom))" }
+        }
       >
         {/* 左侧：状态栏插槽 */}
-        {leftSlot && (
+        {hasLeftSlot && (
           <div className="flex-1 min-w-0 mr-3 overflow-hidden">{leftSlot}</div>
         )}
-
-        {/* 占位：无 leftSlot 时推能量球到右侧 */}
-        {!leftSlot && <div className="flex-1" />}
 
         {/* 右侧：能量球按钮 */}
         <div className="relative flex-shrink-0">


### PR DESCRIPTION
## 问题

移动端关闭“系统状态”后，底部导航仍然渲染整条白色固定栏，只是左侧内容为空，导致页面底部出现大面积无效占位。

## 修复

- 有系统状态内容时：继续保留现有“状态栏 + 菜单按钮”的完整底栏
- 无系统状态内容时：不再渲染全宽背景、顶部边框和空白占位，只保留右下角悬浮菜单按钮
- 菜单按钮继续遵守 `safe-area-inset-bottom`，避免被 iPhone Home Indicator 遮挡
- 展开菜单、遮罩、二级菜单、动画与点击行为保持不变

## 预期效果

用户在后台关闭移动端系统状态后，截图红框中的白色栏消失，仅保留右下角圆形菜单按钮。