### PR TITLE
feat(mobile): 增加分类与标签侧滑导航

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,6 +27,7 @@ import { BentoGrid, BentoGridItem } from "./components/ui/bento-grid";
 import { SpotlightCard } from "./components/ui/spotlight-card";
 import { FloatingDock } from "./components/ui/floating-dock";
 import { MobileFloatingDock } from "./components/ui/mobile-floating-dock";
+import { MobileContentNavigation } from "./components/ui/mobile-content-navigation";
 import { SpotlightSearch } from "./components/ui/spotlight-search";
 import { AiAssistant } from "./components/ui/ai-assistant";
 import { Meteors } from "./components/ui/effects";
@@ -85,6 +86,13 @@ import { Bookmark } from "./types/bookmark";
 import { IconRenderer } from "./components/IconRenderer";
 import { handleQuotesChange } from "./data/quotes";
 import { createDockItems, filterDockItems } from "./config/dockItems";
+import {
+  buildTagStats,
+  filterBookmarksByTag,
+  getTagFromSearch,
+  normalizeTag,
+  writeTagToLocation,
+} from "./lib/bookmark-filter";
 
 // 标签颜色：基于名称哈希生成柔和的彩色药丸
 const TAG_COLORS = [
@@ -115,6 +123,9 @@ function App() {
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false);
   const [categoryModalMode, setCategoryModalMode] = useState<'edit' | 'add'>('edit');
   const [pendingUrl, setPendingUrl] = useState("");
+  const [activeTag, setActiveTag] = useState<string | null>(() =>
+    typeof window === 'undefined' ? null : getTagFromSearch(window.location.search)
+  );
 
   // 右键菜单状态
   const [contextMenu, setContextMenu] = useState<{
@@ -207,8 +218,17 @@ function App() {
     previousLoginStateRef.current = isLoggedIn;
   }, [isLoggedIn, refreshData]);
 
-  // 拖拽功能
+  // 浏览器前进/后退时恢复 URL 中的标签筛选
+  useEffect(() => {
+    const handlePopState = () => {
+      setActiveTag(getTagFromSearch(window.location.search));
+    };
 
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  // 拖拽功能：标签筛选时禁用，避免局部列表重排污染完整顺序
   const {
     activeBookmark,
     sensors,
@@ -216,7 +236,7 @@ function App() {
     handleDragEnd,
     handleDragCancel,
     measuringConfig,
-  } = useDragAndDrop({ bookmarks, reorderBookmarks, disabled: !isLoggedIn });
+  } = useDragAndDrop({ bookmarks, reorderBookmarks, disabled: !isLoggedIn || Boolean(activeTag) });
 
   // 天气数据
 const { weather, loading: weatherLoading, refresh: refreshWeather } = useWeather(showWeather, weatherCity, disableGeolocation, settingsLoaded);
@@ -325,6 +345,7 @@ const { weather, loading: weatherLoading, refresh: refreshWeather } = useWeather
     // 清理 URL，避免刷新页面再次触发
     const cleaned = window.location.pathname + window.location.hash;
     window.history.replaceState({}, '', cleaned);
+    setActiveTag(null);
 
     if (!isLoggedIn) {
       // 未登录：缓存到 sessionStorage，登录成功后再恢复
@@ -444,18 +465,55 @@ const { weather, loading: weatherLoading, refresh: refreshWeather } = useWeather
     [deleteBookmark, t]
   );
 
+  const handleTagSelect = useCallback((tag: string | null) => {
+    const normalizedTag = normalizeTag(tag);
+    const nextTag = normalizedTag && normalizedTag === activeTag ? null : normalizedTag;
+    setActiveTag(nextTag);
+    writeTagToLocation(nextTag);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [activeTag]);
+
+  const handleMobileCategorySelect = useCallback((categoryId: string) => {
+    setActiveTag(null);
+    writeTagToLocation(null);
+
+    window.setTimeout(() => {
+      const section = categoryId === 'pinned'
+        ? document.querySelector("[data-section='pinned']")
+        : document.querySelector(`[data-category-id="${categoryId}"]`);
+
+      if (section) {
+        const top = section.getBoundingClientRect().top + window.scrollY - 88;
+        window.scrollTo({ top, behavior: 'smooth' });
+      }
+    }, 0);
+  }, []);
+
   // ========== 数据分组（useMemo 优化，避免每次渲染重新计算） ==========
-  const pinnedBookmarks = useMemo(() => bookmarks.filter((b) => b.isPinned), [bookmarks]);
+  const tagStats = useMemo(() => buildTagStats(bookmarks), [bookmarks]);
+  const visibleBookmarks = useMemo(
+    () => filterBookmarksByTag(bookmarks, activeTag),
+    [bookmarks, activeTag]
+  );
+  const pinnedBookmarks = useMemo(() => visibleBookmarks.filter((b) => b.isPinned), [visibleBookmarks]);
+  const allPinnedCount = useMemo(() => bookmarks.filter((b) => b.isPinned).length, [bookmarks]);
 
   const bookmarksByCategory = useMemo(() => categories.reduce((acc, cat) => {
-    const categoryBookmarks = bookmarks.filter((b) => b.category === cat.id);
+    const categoryBookmarks = visibleBookmarks.filter((b) => b.category === cat.id);
     acc[cat.id] = categoryBookmarks.sort((a, b) => {
       if (a.isPinned && !b.isPinned) return -1;
       if (!a.isPinned && b.isPinned) return 1;
       return a.orderIndex - b.orderIndex;
     });
     return acc;
-  }, {} as Record<string, Bookmark[]>), [bookmarks, categories]);
+  }, {} as Record<string, Bookmark[]>), [visibleBookmarks, categories]);
+
+  const mobileCategoryItems = useMemo(() => categories
+    .map((category) => ({
+      ...category,
+      count: bookmarks.filter((bookmark) => bookmark.category === category.id).length,
+    }))
+    .filter((category) => category.count > 0), [bookmarks, categories]);
 
   // ========== 页面路由 ==========
   // 后台登录页面
@@ -732,9 +790,42 @@ const { weather, loading: weatherLoading, refresh: refreshWeather } = useWeather
             onOpenSearch={() => setIsSpotlightOpen(true)}
           />
 
+          {activeTag && (
+            <motion.div
+              className="mb-6 flex flex-wrap items-center gap-2 rounded-2xl px-4 py-3 backdrop-blur-xl"
+              style={{ background: 'var(--color-glass)', border: '1px solid var(--color-glass-border)' }}
+              initial={{ opacity: 0, y: -8 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                {t('mobileNavigation.activeFilter', '当前筛选')}
+              </span>
+              <button
+                type="button"
+                onClick={() => handleTagSelect(null)}
+                className="rounded-lg px-2.5 py-1 text-sm font-medium"
+                style={{ background: 'var(--color-primary-light)', color: 'var(--color-primary)', border: '1px solid var(--color-primary)' }}
+              >
+                #{activeTag}
+              </button>
+              <span className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                {visibleBookmarks.length} {t('mobileNavigation.results', '个结果')}
+              </span>
+              <button
+                type="button"
+                aria-label={t('mobileNavigation.clear', '清除标签筛选')}
+                onClick={() => handleTagSelect(null)}
+                className="ml-auto flex h-8 w-8 items-center justify-center rounded-lg text-lg"
+                style={{ background: 'var(--color-bg-tertiary)', color: 'var(--color-text-muted)' }}
+              >
+                ×
+              </button>
+            </motion.div>
+          )}
+
           {/* Read Later Section */}
           <ReadLaterSection
-            bookmarks={bookmarks}
+            bookmarks={visibleBookmarks}
             isLiteMode={isLiteMode ?? false}
             onMarkRead={toggleRead}
             onRemove={toggleReadLater}
@@ -820,6 +911,7 @@ const { weather, loading: weatherLoading, refresh: refreshWeather } = useWeather
                         setIsAddModalOpen(true);
                       }}
                       onDelete={() => handleDelete(bookmark.id)}
+                      onTagSelect={handleTagSelect}
                     />
                   </BentoGridItem>
                 ))}
@@ -878,7 +970,7 @@ const { weather, loading: weatherLoading, refresh: refreshWeather } = useWeather
                   catIndex={catIndex}
                   isLiteMode={isLiteMode}
                   isInternal={isInternal}
-                  totalBookmarkCount={bookmarks.length}
+                  totalBookmarkCount={visibleBookmarks.length}
                   collapseThreshold={categoryCollapseThreshold}
                   initialShowCount={categoryInitialShowCount}
                   cardViewMode={cardViewMode}
@@ -889,6 +981,7 @@ const { weather, loading: weatherLoading, refresh: refreshWeather } = useWeather
                     setIsCategoryModalOpen(true);
                   }}
                   onViewModeChange={handleCardViewModeChange}
+                  onTagSelect={handleTagSelect}
                   isLoggedIn={isLoggedIn}
                 />
               );
@@ -899,7 +992,28 @@ const { weather, loading: weatherLoading, refresh: refreshWeather } = useWeather
           </DndContext>
 
           {/* Empty State */}
-          {bookmarks.length === 0 && !isLoading && (
+          {activeTag && visibleBookmarks.length === 0 && !isLoading && (
+            <motion.div
+              className="mb-12 flex flex-col items-center justify-center rounded-3xl px-6 py-14 text-center"
+              style={{ background: 'var(--color-glass)', border: '1px solid var(--color-glass-border)' }}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
+              <p className="text-lg font-medium" style={{ color: 'var(--color-text-primary)' }}>
+                {t('mobileNavigation.noResults', '没有找到包含该标签的书签')}
+              </p>
+              <p className="mt-2 text-sm" style={{ color: 'var(--color-text-muted)' }}>#{activeTag}</p>
+              <button
+                type="button"
+                onClick={() => handleTagSelect(null)}
+                className="mt-5 rounded-xl px-4 py-2 text-sm font-medium"
+                style={{ background: 'var(--color-primary)', color: '#fff' }}
+              >
+                {t('mobileNavigation.clear', '清除标签筛选')}
+              </button>
+            </motion.div>
+          )}
+          {!activeTag && bookmarks.length === 0 && !isLoading && (
             <EmptyState isLiteMode={isLiteMode ?? false} isLoggedIn={isLoggedIn} onAddBookmark={() => setIsAddModalOpen(true)} />
           )}
         </div>
@@ -1004,6 +1118,19 @@ const { weather, loading: weatherLoading, refresh: refreshWeather } = useWeather
 
     {/* 以下组件放在 BackgroundWrapper 外部，避免被其 stacking context 限制 z-index */}
 
+    {enableSidebarNav && (
+      <MobileContentNavigation
+        categories={mobileCategoryItems}
+        tags={tagStats}
+        pinnedCount={allPinnedCount}
+        totalBookmarks={bookmarks.length}
+        activeTag={activeTag}
+        matchedCount={visibleBookmarks.length}
+        onSelectTag={handleTagSelect}
+        onSelectCategory={handleMobileCategorySelect}
+      />
+    )}
+
     {/* 桌面端：Dock（自主管理 fixed 定位 + 自由拖拽） */}
     <div className="hidden md:block">
       <FloatingDock
@@ -1086,6 +1213,7 @@ const MemoizedBookmarkItem = React.memo(function MemoizedBookmarkItem({
   lightweight,
   cardViewMode = 'standard',
   onContextMenu,
+  onTagSelect,
 }: {
   bookmark: Bookmark;
   index: number;
@@ -1095,6 +1223,7 @@ const MemoizedBookmarkItem = React.memo(function MemoizedBookmarkItem({
   lightweight: boolean;
   cardViewMode?: 'compact' | 'standard' | 'comfortable';
   onContextMenu: (e: React.MouseEvent, bookmark: Bookmark) => void;
+  onTagSelect: (tag: string) => void;
 }) {
   const animDelay = index < MAX_ANIMATED_INDEX ? index * 0.04 : 0;
   const isCompact = cardViewMode === 'compact';
@@ -1172,18 +1301,24 @@ const MemoizedBookmarkItem = React.memo(function MemoizedBookmarkItem({
             {bookmark.tags.slice(0, 3).map(tag => {
               const color = getTagColor(tag)
               return (
-                <span
+                <button
                   key={tag}
-                  className="px-1.5 py-0.5 rounded-md text-[10px] leading-tight font-medium truncate max-w-[80px]"
+                  type="button"
+                  className="px-1.5 py-0.5 rounded-md text-[10px] leading-tight font-medium truncate max-w-[80px] transition-transform hover:scale-105 active:scale-95"
                   style={{
                     background: color.bg,
                     color: color.text,
                     border: `1px solid ${color.border}`,
                   }}
                   title={tag}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onTagSelect(tag);
+                  }}
                 >
                   #{tag}
-                </span>
+                </button>
               )
             })}
             {bookmark.tags.length > 3 && (
@@ -1366,6 +1501,7 @@ function CategorySection({
   onContextMenu,
   onEditCategory,
   onViewModeChange,
+  onTagSelect,
   isLoggedIn,
 }: {
   category: import("./types/bookmark").Category;
@@ -1380,6 +1516,7 @@ function CategorySection({
   onContextMenu: (e: React.MouseEvent, bookmark: Bookmark) => void;
   onEditCategory: (cat: import("./types/bookmark").Category) => void;
   onViewModeChange?: (mode: 'compact' | 'standard' | 'comfortable') => void;
+  onTagSelect: (tag: string) => void;
   isLoggedIn?: boolean;
 }) {
   const { t } = useTranslation();
@@ -1469,6 +1606,7 @@ function CategorySection({
               lightweight={lightweight}
               cardViewMode={cardViewMode}
               onContextMenu={onContextMenu}
+              onTagSelect={onTagSelect}
             />
           )) : null}
         </div>

--- a/src/components/BookmarkCardContent.tsx
+++ b/src/components/BookmarkCardContent.tsx
@@ -32,6 +32,7 @@ export interface BookmarkCardContentProps {
   onToggleReadLater: () => void;
   onEdit: () => void;
   onDelete: () => void;
+  onTagSelect?: (tag: string) => void;
 }
 
 export function BookmarkCardContent({
@@ -43,6 +44,7 @@ export function BookmarkCardContent({
   onToggleReadLater,
   onEdit,
   onDelete,
+  onTagSelect,
 }: BookmarkCardContentProps) {
   const [showActions, setShowActions] = useState(false);
   const { t } = useTranslation();
@@ -200,17 +202,30 @@ export function BookmarkCardContent({
           <div className="flex flex-wrap gap-1 mt-2">
             {bookmark.tags.slice(0, 3).map(tag => {
               const color = getTagColor(tag)
-              return (
-                <span
+              const tagClassName = "px-1.5 py-0.5 rounded-md text-[10px] leading-tight font-medium truncate max-w-[80px]"
+              const tagStyle = {
+                background: color.bg,
+                color: color.text,
+                border: `1px solid ${color.border}`,
+              }
+
+              return onTagSelect ? (
+                <button
                   key={tag}
-                  className="px-1.5 py-0.5 rounded-md text-[10px] leading-tight font-medium truncate max-w-[80px]"
-                  style={{
-                    background: color.bg,
-                    color: color.text,
-                    border: `1px solid ${color.border}`,
-                  }}
+                  type="button"
+                  className={`${tagClassName} transition-transform hover:scale-105 active:scale-95`}
+                  style={tagStyle}
                   title={tag}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onTagSelect(tag);
+                  }}
                 >
+                  #{tag}
+                </button>
+              ) : (
+                <span key={tag} className={tagClassName} style={tagStyle} title={tag}>
                   #{tag}
                 </span>
               )

--- a/src/components/ui/mobile-content-navigation.tsx
+++ b/src/components/ui/mobile-content-navigation.tsx
@@ -1,0 +1,323 @@
+import { useEffect, useMemo, useState } from 'react'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Check, FolderTree, LayoutList, Pin, Tags, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Category } from '../../types/bookmark'
+import { TagStat } from '../../lib/bookmark-filter'
+import { IconRenderer } from '../IconRenderer'
+
+interface CategoryNavigationItem extends Category {
+  count: number
+}
+
+interface MobileContentNavigationProps {
+  categories: CategoryNavigationItem[]
+  tags: TagStat[]
+  pinnedCount: number
+  totalBookmarks: number
+  activeTag: string | null
+  matchedCount: number
+  onSelectTag: (tag: string | null) => void
+  onSelectCategory: (categoryId: string) => void
+}
+
+type NavigationTab = 'categories' | 'tags'
+
+const COPY = {
+  zh: {
+    navigation: '内容导航',
+    categories: '分类',
+    tags: '标签',
+    pinned: '常用',
+    allTags: '全部标签',
+    popularTags: '常用标签',
+    moreTags: '更多标签',
+    allBookmarks: '全部书签',
+    selected: '当前筛选',
+    emptyTags: '还没有可选择的标签',
+    close: '关闭内容导航',
+    open: '打开分类和标签导航',
+  },
+  en: {
+    navigation: 'Content navigation',
+    categories: 'Categories',
+    tags: 'Tags',
+    pinned: 'Pinned',
+    allTags: 'All tags',
+    popularTags: 'Popular tags',
+    moreTags: 'More tags',
+    allBookmarks: 'All bookmarks',
+    selected: 'Active filter',
+    emptyTags: 'No tags are available yet',
+    close: 'Close content navigation',
+    open: 'Open category and tag navigation',
+  },
+  ja: {
+    navigation: 'コンテンツナビ',
+    categories: 'カテゴリー',
+    tags: 'タグ',
+    pinned: 'よく使う項目',
+    allTags: 'すべてのタグ',
+    popularTags: 'よく使うタグ',
+    moreTags: 'その他のタグ',
+    allBookmarks: 'すべてのブックマーク',
+    selected: '現在の絞り込み',
+    emptyTags: '選択できるタグがありません',
+    close: 'ナビゲーションを閉じる',
+    open: 'カテゴリーとタグを開く',
+  },
+  ko: {
+    navigation: '콘텐츠 탐색',
+    categories: '카테고리',
+    tags: '태그',
+    pinned: '자주 사용',
+    allTags: '모든 태그',
+    popularTags: '자주 쓰는 태그',
+    moreTags: '더 많은 태그',
+    allBookmarks: '모든 북마크',
+    selected: '현재 필터',
+    emptyTags: '선택할 태그가 없습니다',
+    close: '콘텐츠 탐색 닫기',
+    open: '카테고리 및 태그 열기',
+  },
+} as const
+
+const TAG_COLORS = [
+  { bg: 'rgba(59,130,246,0.14)', text: 'rgb(96,165,250)', border: 'rgba(59,130,246,0.28)' },
+  { bg: 'rgba(16,185,129,0.14)', text: 'rgb(52,211,153)', border: 'rgba(16,185,129,0.28)' },
+  { bg: 'rgba(245,158,11,0.14)', text: 'rgb(251,191,36)', border: 'rgba(245,158,11,0.28)' },
+  { bg: 'rgba(239,68,68,0.14)', text: 'rgb(248,113,113)', border: 'rgba(239,68,68,0.28)' },
+  { bg: 'rgba(139,92,246,0.14)', text: 'rgb(167,139,250)', border: 'rgba(139,92,246,0.28)' },
+  { bg: 'rgba(236,72,153,0.14)', text: 'rgb(244,114,182)', border: 'rgba(236,72,153,0.28)' },
+]
+
+function getTagColor(name: string) {
+  let hash = 0
+  for (let index = 0; index < name.length; index += 1) {
+    hash = ((hash << 5) - hash + name.charCodeAt(index)) | 0
+  }
+  return TAG_COLORS[Math.abs(hash) % TAG_COLORS.length]
+}
+
+export function MobileContentNavigation({
+  categories,
+  tags,
+  pinnedCount,
+  totalBookmarks,
+  activeTag,
+  matchedCount,
+  onSelectTag,
+  onSelectCategory,
+}: MobileContentNavigationProps) {
+  const { i18n } = useTranslation()
+  const language = i18n.language.split('-')[0] as keyof typeof COPY
+  const copy = COPY[language] || COPY.en
+  const [open, setOpen] = useState(false)
+  const [activeTab, setActiveTab] = useState<NavigationTab>(activeTag ? 'tags' : 'categories')
+
+  const popularTags = useMemo(() => tags.slice(0, 12), [tags])
+  const remainingTags = useMemo(() => tags.slice(12), [tags])
+
+  useEffect(() => {
+    if (activeTag) setActiveTab('tags')
+  }, [activeTag])
+
+  useEffect(() => {
+    if (!open) return
+
+    const previousOverflow = document.body.style.overflow
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+    const handlePopState = () => setOpen(false)
+
+    document.body.style.overflow = 'hidden'
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('popstate', handlePopState)
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('popstate', handlePopState)
+    }
+  }, [open])
+
+  if (categories.length === 0 && tags.length === 0 && pinnedCount === 0) return null
+
+  const selectTag = (tag: string | null) => {
+    setOpen(false)
+    onSelectTag(tag)
+  }
+
+  const selectCategory = (categoryId: string) => {
+    setOpen(false)
+    onSelectCategory(categoryId)
+  }
+
+  const renderTag = (tag: TagStat) => {
+    const selected = activeTag === tag.name
+    const color = getTagColor(tag.name)
+
+    return (
+      <button
+        key={tag.name}
+        type="button"
+        onClick={() => selectTag(selected ? null : tag.name)}
+        className="flex min-h-11 w-full items-center gap-3 rounded-xl px-3 py-2 text-left transition-transform active:scale-[0.98]"
+        style={{
+          background: selected ? color.bg : 'var(--color-bg-tertiary)',
+          border: `1px solid ${selected ? color.border : 'var(--color-glass-border)'}`,
+        }}
+      >
+        <span
+          className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg"
+          style={{ background: color.bg, color: color.text }}
+        >
+          <Tags className="h-4 w-4" />
+        </span>
+        <span className="min-w-0 flex-1 truncate text-sm font-medium" style={{ color: selected ? color.text : 'var(--color-text-primary)' }}>
+          #{tag.name}
+        </span>
+        <span className="text-xs tabular-nums" style={{ color: 'var(--color-text-muted)' }}>{tag.count}</span>
+        {selected && <Check className="h-4 w-4 flex-shrink-0" style={{ color: color.text }} />}
+      </button>
+    )
+  }
+
+  return (
+    <>
+      <motion.button
+        type="button"
+        aria-label={copy.open}
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+        className="fixed left-2 top-[56%] z-50 flex h-11 w-11 -translate-y-1/2 items-center justify-center rounded-full backdrop-blur-xl lg:hidden"
+        style={{
+          background: 'var(--color-glass)',
+          border: '1px solid var(--color-glass-border)',
+          boxShadow: '0 8px 28px rgba(0,0,0,0.22)',
+          color: activeTag ? 'var(--color-primary)' : 'var(--color-text-secondary)',
+        }}
+        whileTap={{ scale: 0.9 }}
+      >
+        <LayoutList className="h-5 w-5" />
+        <span className="absolute -right-1 -top-1 flex h-[18px] min-w-[18px] items-center justify-center rounded-full px-1 text-[10px] font-semibold text-white" style={{ background: 'var(--color-primary)' }}>
+          {activeTag ? matchedCount : tags.length > 99 ? '99+' : tags.length}
+        </span>
+      </motion.button>
+
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            className="fixed inset-0 z-[80] lg:hidden"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+          >
+            <motion.button
+              type="button"
+              aria-label={copy.close}
+              className="absolute inset-0 bg-black/55 backdrop-blur-[2px]"
+              onClick={() => setOpen(false)}
+            />
+
+            <motion.aside
+              role="dialog"
+              aria-modal="true"
+              aria-label={copy.navigation}
+              className="absolute bottom-0 left-0 top-0 flex flex-col overflow-hidden rounded-r-3xl"
+              style={{
+                width: 'min(82vw, 320px)',
+                paddingTop: 'max(16px, env(safe-area-inset-top))',
+                paddingBottom: 'max(16px, env(safe-area-inset-bottom))',
+                background: 'var(--color-bg-secondary)',
+                borderRight: '1px solid var(--color-glass-border)',
+                boxShadow: '20px 0 60px rgba(0,0,0,0.35)',
+              }}
+              initial={{ x: '-100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '-100%' }}
+              transition={{ type: 'spring', stiffness: 360, damping: 34 }}
+            >
+              <div className="flex items-center gap-3 px-5 pb-4">
+                <div className="flex h-10 w-10 items-center justify-center rounded-xl" style={{ background: 'var(--color-primary-light)', color: 'var(--color-primary)' }}>
+                  <LayoutList className="h-5 w-5" />
+                </div>
+                <div className="min-w-0 flex-1">
+                  <h2 className="font-semibold" style={{ color: 'var(--color-text-primary)' }}>{copy.navigation}</h2>
+                  <p className="text-xs" style={{ color: 'var(--color-text-muted)' }}>
+                    {activeTag ? `${copy.selected}：#${activeTag}` : `${totalBookmarks} ${copy.allBookmarks}`}
+                  </p>
+                </div>
+                <button type="button" aria-label={copy.close} onClick={() => setOpen(false)} className="flex h-10 w-10 items-center justify-center rounded-xl" style={{ color: 'var(--color-text-muted)', background: 'var(--color-bg-tertiary)' }}>
+                  <X className="h-5 w-5" />
+                </button>
+              </div>
+
+              <div className="mx-5 mb-4 grid grid-cols-2 rounded-xl p-1" style={{ background: 'var(--color-bg-tertiary)' }}>
+                <button type="button" onClick={() => setActiveTab('categories')} className="flex min-h-10 items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors" style={{ background: activeTab === 'categories' ? 'var(--color-glass)' : 'transparent', color: activeTab === 'categories' ? 'var(--color-text-primary)' : 'var(--color-text-muted)' }}>
+                  <FolderTree className="h-4 w-4" /> {copy.categories}
+                </button>
+                <button type="button" onClick={() => setActiveTab('tags')} className="flex min-h-10 items-center justify-center gap-2 rounded-lg text-sm font-medium transition-colors" style={{ background: activeTab === 'tags' ? 'var(--color-glass)' : 'transparent', color: activeTab === 'tags' ? 'var(--color-text-primary)' : 'var(--color-text-muted)' }}>
+                  <Tags className="h-4 w-4" /> {copy.tags}
+                </button>
+              </div>
+
+              <div className="flex-1 overflow-y-auto overscroll-contain px-5 pb-6">
+                {activeTab === 'categories' ? (
+                  <div className="space-y-2">
+                    {pinnedCount > 0 && (
+                      <button type="button" onClick={() => selectCategory('pinned')} className="flex min-h-12 w-full items-center gap-3 rounded-xl px-3 py-2 text-left" style={{ background: 'var(--color-bg-tertiary)', border: '1px solid var(--color-glass-border)' }}>
+                        <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-yellow-500/15 text-yellow-400"><Pin className="h-4 w-4" /></span>
+                        <span className="flex-1 text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>{copy.pinned}</span>
+                        <span className="text-xs tabular-nums" style={{ color: 'var(--color-text-muted)' }}>{pinnedCount}</span>
+                      </button>
+                    )}
+                    {categories.map((category) => (
+                      <button key={category.id} type="button" onClick={() => selectCategory(category.id)} className="flex min-h-12 w-full items-center gap-3 rounded-xl px-3 py-2 text-left" style={{ background: 'var(--color-bg-tertiary)', border: '1px solid var(--color-glass-border)' }}>
+                        <span className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ color: category.color || 'var(--color-primary)', background: `${category.color || '#667eea'}18` }}>
+                          <IconRenderer icon={category.icon} className="h-4 w-4" />
+                        </span>
+                        <span className="min-w-0 flex-1 truncate text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>{category.name}</span>
+                        <span className="text-xs tabular-nums" style={{ color: 'var(--color-text-muted)' }}>{category.count}</span>
+                      </button>
+                    ))}
+                  </div>
+                ) : tags.length > 0 ? (
+                  <div className="space-y-5">
+                    <div className="space-y-2">
+                      <p className="px-1 text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }}>{copy.allTags}</p>
+                      <button type="button" onClick={() => selectTag(null)} className="flex min-h-11 w-full items-center gap-3 rounded-xl px-3 py-2 text-left" style={{ background: activeTag === null ? 'var(--color-primary-light)' : 'var(--color-bg-tertiary)', border: `1px solid ${activeTag === null ? 'var(--color-primary)' : 'var(--color-glass-border)'}` }}>
+                        <span className="flex h-8 w-8 items-center justify-center rounded-lg" style={{ background: 'var(--color-primary-light)', color: 'var(--color-primary)' }}><LayoutList className="h-4 w-4" /></span>
+                        <span className="flex-1 text-sm font-medium" style={{ color: 'var(--color-text-primary)' }}>{copy.allBookmarks}</span>
+                        <span className="text-xs tabular-nums" style={{ color: 'var(--color-text-muted)' }}>{totalBookmarks}</span>
+                        {activeTag === null && <Check className="h-4 w-4" style={{ color: 'var(--color-primary)' }} />}
+                      </button>
+                    </div>
+
+                    <div className="space-y-2">
+                      <p className="px-1 text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }}>{copy.popularTags}</p>
+                      {popularTags.map(renderTag)}
+                    </div>
+
+                    {remainingTags.length > 0 && (
+                      <div className="space-y-2">
+                        <p className="px-1 text-xs font-medium uppercase tracking-wider" style={{ color: 'var(--color-text-muted)' }}>{copy.moreTags}</p>
+                        {remainingTags.map(renderTag)}
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+                    <Tags className="h-9 w-9" style={{ color: 'var(--color-text-muted)' }} />
+                    <p className="text-sm" style={{ color: 'var(--color-text-muted)' }}>{copy.emptyTags}</p>
+                  </div>
+                )}
+              </div>
+            </motion.aside>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
+  )
+}

--- a/src/lib/__tests__/bookmark-filter.test.ts
+++ b/src/lib/__tests__/bookmark-filter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { Bookmark } from '../../types/bookmark'
+import {
+  buildTagStats,
+  buildTagUrl,
+  filterBookmarksByTag,
+  getTagFromSearch,
+} from '../bookmark-filter'
+
+const bookmarks: Bookmark[] = [
+  {
+    id: '1',
+    url: 'https://example.com/one',
+    title: 'One',
+    tags: ['Docker', 'NAS', 'Docker'],
+    orderIndex: 0,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  {
+    id: '2',
+    url: 'https://example.com/two',
+    title: 'Two',
+    tags: ['Docker', 'AI'],
+    orderIndex: 1,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+  {
+    id: '3',
+    url: 'https://example.com/three',
+    title: 'Three',
+    orderIndex: 2,
+    createdAt: 1,
+    updatedAt: 1,
+  },
+]
+
+describe('bookmark tag filtering', () => {
+  it('filters bookmarks by one exact tag and keeps all bookmarks without a filter', () => {
+    expect(filterBookmarksByTag(bookmarks, 'Docker').map((bookmark) => bookmark.id)).toEqual(['1', '2'])
+    expect(filterBookmarksByTag(bookmarks, null)).toBe(bookmarks)
+  })
+
+  it('counts each tag once per bookmark and sorts by usage', () => {
+    expect(buildTagStats(bookmarks)).toEqual([
+      { name: 'Docker', count: 2 },
+      { name: 'AI', count: 1 },
+      { name: 'NAS', count: 1 },
+    ])
+  })
+
+  it('reads and writes a shareable tag query without dropping other parameters or hashes', () => {
+    expect(getTagFromSearch('?tag=Docker')).toBe('Docker')
+    expect(buildTagUrl('https://nowen.example/?view=grid#bookmarks', 'Docker')).toBe('/?view=grid&tag=Docker#bookmarks')
+    expect(buildTagUrl('https://nowen.example/?view=grid&tag=Docker#bookmarks', null)).toBe('/?view=grid#bookmarks')
+  })
+})

--- a/src/lib/bookmark-filter.ts
+++ b/src/lib/bookmark-filter.ts
@@ -1,0 +1,73 @@
+import { Bookmark } from '../types/bookmark'
+
+export interface TagStat {
+  name: string
+  count: number
+}
+
+export function normalizeTag(value: string | null | undefined): string | null {
+  const normalized = value?.trim()
+  return normalized ? normalized : null
+}
+
+export function getTagFromSearch(search: string): string | null {
+  return normalizeTag(new URLSearchParams(search).get('tag'))
+}
+
+export function buildTagUrl(href: string, tag: string | null): string {
+  const url = new URL(href)
+  const normalizedTag = normalizeTag(tag)
+
+  if (normalizedTag) {
+    url.searchParams.set('tag', normalizedTag)
+  } else {
+    url.searchParams.delete('tag')
+  }
+
+  return `${url.pathname}${url.search}${url.hash}`
+}
+
+export function writeTagToLocation(
+  tag: string | null,
+  mode: 'push' | 'replace' = 'push',
+): void {
+  if (typeof window === 'undefined') return
+
+  const nextUrl = buildTagUrl(window.location.href, tag)
+  const state = { ...window.history.state, nowenTag: normalizeTag(tag) }
+
+  if (mode === 'replace') {
+    window.history.replaceState(state, '', nextUrl)
+  } else {
+    window.history.pushState(state, '', nextUrl)
+  }
+}
+
+export function filterBookmarksByTag(bookmarks: Bookmark[], tag: string | null): Bookmark[] {
+  const normalizedTag = normalizeTag(tag)
+  if (!normalizedTag) return bookmarks
+
+  return bookmarks.filter((bookmark) =>
+    bookmark.tags?.some((bookmarkTag) => bookmarkTag.trim() === normalizedTag),
+  )
+}
+
+export function buildTagStats(bookmarks: Bookmark[]): TagStat[] {
+  const counts = new Map<string, number>()
+
+  bookmarks.forEach((bookmark) => {
+    const uniqueTags = new Set(
+      (bookmark.tags || [])
+        .map((tag) => tag.trim())
+        .filter(Boolean),
+    )
+
+    uniqueTags.forEach((tag) => {
+      counts.set(tag, (counts.get(tag) || 0) + 1)
+    })
+  })
+
+  return Array.from(counts, ([name, count]) => ({ name, count })).sort(
+    (left, right) => right.count - left.count || left.name.localeCompare(right.name, 'zh-CN'),
+  )
+}


### PR DESCRIPTION
## 用户问题
移动端标签变多后，用户不希望先记住标签名称再输入搜索，希望从左侧直接浏览并选择标签。

## 实现
- 移动端左侧增加 44px 悬浮导航入口，不常驻占用内容宽度
- 点击后打开左侧抽屉，提供“分类 / 标签”双页签
- 分类页支持常用区和分类快速滚动
- 标签页按使用次数展示常用标签和更多标签，显示对应书签数量
- 第一版采用单标签筛选，再次点击当前标签或“全部书签”即可清除
- 标签筛选同步到 `?tag=`，刷新、分享、浏览器前进和后退可恢复状态
- 置顶、稍后阅读和分类书签使用同一份筛选结果
- 当前筛选条件、结果数量和无结果状态均有明确反馈
- 置顶卡片及普通分类卡片上的标签可直接点击筛选，并阻止书签打开事件
- 标签筛选期间禁用拖拽，避免局部列表重排污染完整排序
- 抽屉适配安全区域、锁定页面滚动并支持 Escape / 浏览器返回关闭

## 测试
- 标签精确筛选
- 单个书签内重复标签去重计数
- 标签统计按使用次数排序
- URL 参数读写不丢失其他参数和 hash

## 验收重点
1. 手机端点击左侧入口可打开抽屉
2. 分类点击后清除标签筛选并平滑滚动
3. 标签点击后置顶、稍后阅读和分类区同步筛选
4. 点击卡片标签不会打开书签
5. `?tag=` 刷新及前进后退状态正确
6. 无匹配结果时可一键清除筛选
7. 桌面端原有侧边栏保持不变
