### PR TITLE
feat(dev): add one-command full-stack startup with automatic ports

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.1.4",
   "type": "module",
   "scripts": {
-    "dev": "vite --mode development",
+    "dev": "node scripts/dev.mjs",
+    "dev:web": "vite --mode development",
     "build": "vite build --mode production",
     "build:dev": "vite build --mode development",
     "preview": "vite preview",

--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -1,0 +1,158 @@
+import { spawn } from 'node:child_process'
+import { createServer } from 'node:net'
+import path from 'node:path'
+import process from 'node:process'
+import { fileURLToPath } from 'node:url'
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const serverDir = path.join(rootDir, 'server')
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
+const isWindows = process.platform === 'win32'
+
+function parsePort(value, fallback) {
+  const port = Number.parseInt(value ?? '', 10)
+  return Number.isInteger(port) && port > 0 && port <= 65535 ? port : fallback
+}
+
+function isPortAvailable(port) {
+  return new Promise((resolve) => {
+    const tester = createServer()
+
+    tester.unref()
+    tester.once('error', () => resolve(false))
+    tester.listen({ host: '0.0.0.0', port, exclusive: true }, () => {
+      tester.close(() => resolve(true))
+    })
+  })
+}
+
+async function findAvailablePort(preferredPort, excludedPorts = new Set()) {
+  for (let port = preferredPort; port <= 65535; port += 1) {
+    if (excludedPorts.has(port)) continue
+    if (await isPortAvailable(port)) return port
+  }
+
+  throw new Error(`No available port found from ${preferredPort} to 65535`)
+}
+
+function describePort(name, preferredPort, selectedPort) {
+  if (preferredPort === selectedPort) {
+    console.log(`  ${name}: ${selectedPort}`)
+    return
+  }
+
+  console.log(`  ${name}: ${preferredPort} is occupied, using ${selectedPort}`)
+}
+
+const preferredApiPort = parsePort(
+  process.env.NOWEN_API_PORT ?? process.env.PORT,
+  3001,
+)
+const preferredWebPort = parsePort(process.env.NOWEN_WEB_PORT, 5173)
+
+const apiPort = await findAvailablePort(preferredApiPort)
+const webPort = await findAvailablePort(preferredWebPort, new Set([apiPort]))
+const apiUrl = `http://localhost:${apiPort}`
+const webUrl = `http://localhost:${webPort}`
+
+console.log('\n🚀 NOWEN development environment')
+describePort('API', preferredApiPort, apiPort)
+describePort('Web', preferredWebPort, webPort)
+console.log(`\n  Open: ${webUrl}\n`)
+
+const children = new Map()
+let shuttingDown = false
+let requestedExitCode = 0
+let forceExitTimer
+
+function stopProcess(child) {
+  if (!child.pid || child.exitCode !== null) return
+
+  if (isWindows) {
+    spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+      stdio: 'ignore',
+      windowsHide: true,
+    })
+    return
+  }
+
+  try {
+    process.kill(-child.pid, 'SIGTERM')
+  } catch {
+    child.kill('SIGTERM')
+  }
+}
+
+function shutdown(exitCode = 0) {
+  if (shuttingDown) return
+
+  shuttingDown = true
+  requestedExitCode = exitCode
+  console.log('\nStopping NOWEN development services...')
+
+  for (const child of children.values()) {
+    stopProcess(child)
+  }
+
+  forceExitTimer = setTimeout(() => {
+    process.exit(requestedExitCode)
+  }, 3000)
+  forceExitTimer.unref()
+}
+
+function startService(name, args, options) {
+  const child = spawn(npmCommand, args, {
+    ...options,
+    detached: !isWindows,
+    shell: isWindows,
+    stdio: 'inherit',
+  })
+
+  children.set(name, child)
+
+  child.once('error', (error) => {
+    console.error(`\n❌ Failed to start ${name}:`, error)
+    shutdown(1)
+  })
+
+  child.once('exit', (code, signal) => {
+    children.delete(name)
+
+    if (!shuttingDown) {
+      console.error(
+        `\n❌ ${name} stopped unexpectedly (${signal ?? `exit code ${code ?? 1}`})`,
+      )
+      shutdown(code ?? 1)
+      return
+    }
+
+    if (children.size === 0) {
+      if (forceExitTimer) clearTimeout(forceExitTimer)
+      process.exit(requestedExitCode)
+    }
+  })
+
+  return child
+}
+
+startService('API server', ['run', 'dev'], {
+  cwd: serverDir,
+  env: {
+    ...process.env,
+    PORT: String(apiPort),
+    DB_PATH:
+      process.env.DB_PATH ??
+      path.join(rootDir, 'server', 'data', 'zen-garden.db'),
+  },
+})
+
+startService('Web client', ['run', 'dev:web', '--', '--port', String(webPort), '--strictPort'], {
+  cwd: rootDir,
+  env: {
+    ...process.env,
+    VITE_API_BASE: apiUrl,
+  },
+})
+
+process.once('SIGINT', () => shutdown(0))
+process.once('SIGTERM', () => shutdown(0))


### PR DESCRIPTION
## 目标

将本地开发启动方式收敛为一条命令，同时避免前端 `5173` 或后端 `3001` 被占用时启动失败。

## 使用方式

首次安装依赖后，在项目根目录执行：

```bash
npm run dev
```

启动器会同时运行：

- Express 后端开发服务
- Vite 前端开发服务

## 端口处理

- 后端优先使用 `3001`
- 前端优先使用 `5173`
- 端口被占用时，从当前端口开始向后自动寻找可用端口
- 前端 `VITE_API_BASE` 自动指向实际选中的后端端口
- 控制台会明确输出最终访问地址

可通过环境变量指定首选端口：

```bash
NOWEN_API_PORT=4001 NOWEN_WEB_PORT=6000 npm run dev
```

## 其他处理

- `Ctrl+C` 会同时停止前端、后端及其子进程
- 兼容 Linux、macOS、Windows 和 WSL
- 开发数据库路径固定为项目内 `server/data/zen-garden.db`，避免从 `server` 工作目录启动时落到错误的嵌套目录
- 保留 `npm run dev:web` 作为只启动前端的入口

## 验证

使用伪造 npm 子进程和真实端口占用测试验证：

- `3001` 被占用时自动选择 `3002`
- `5173` 被占用时自动选择 `5174`
- 前端收到 `VITE_API_BASE=http://localhost:3002`
- 后端收到 `PORT=3002`
- `Ctrl+C` 可同时结束两个进程组
- `node --check scripts/dev.mjs` 语法检查通过