### PR TITLE
feat(ui): support background middle-click for bookmark cards

### DIFF
--- a/src/components/ui/__tests__/spotlight-card.test.tsx
+++ b/src/components/ui/__tests__/spotlight-card.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { SpotlightCard } from '../spotlight-card'
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+function getCard(container: HTMLElement) {
+  const card = container.querySelector<HTMLElement>('[data-test-card]')
+  if (!card) throw new Error('SpotlightCard was not rendered')
+  return card
+}
+
+describe('SpotlightCard middle click', () => {
+  it('runs the bookmark action on middle click and keeps focus on the current page', () => {
+    const onClick = vi.fn()
+    const focusSpy = vi.spyOn(window, 'focus').mockImplementation(() => undefined)
+    const { container } = render(
+      <SpotlightCard
+        className="test-card"
+        onClick={onClick}
+        onContextMenu={() => undefined}
+      >
+        <span>Bookmark</span>
+      </SpotlightCard>,
+    )
+
+    const card = container.querySelector<HTMLElement>('.test-card')
+    expect(card).toBeTruthy()
+
+    fireEvent.auxClick(card!, { button: 1 })
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+    expect(focusSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('prevents middle-button auto-scroll before opening the bookmark', () => {
+    const { container } = render(
+      <SpotlightCard
+        className="test-card"
+        lightweight
+        onClick={() => undefined}
+        onContextMenu={() => undefined}
+      >
+        <span>Bookmark</span>
+      </SpotlightCard>,
+    )
+
+    const card = container.querySelector<HTMLElement>('.test-card')
+    expect(card).toBeTruthy()
+    expect(fireEvent.mouseDown(card!, { button: 1 })).toBe(false)
+  })
+
+  it('does not open the bookmark when middle-clicking a nested action', () => {
+    const onClick = vi.fn()
+    const { getByRole } = render(
+      <SpotlightCard
+        lightweight
+        onClick={onClick}
+        onContextMenu={() => undefined}
+      >
+        <button type="button">Pin bookmark</button>
+      </SpotlightCard>,
+    )
+
+    fireEvent.auxClick(getByRole('button', { name: 'Pin bookmark' }), { button: 1 })
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+
+  it('ignores right-button auxiliary clicks and supports explicit opt-out', () => {
+    const onClick = vi.fn()
+    const { container } = render(
+      <SpotlightCard
+        className="test-card"
+        lightweight
+        onClick={onClick}
+        onContextMenu={() => undefined}
+        openOnMiddleClick={false}
+      >
+        <span>Bookmark</span>
+      </SpotlightCard>,
+    )
+
+    const card = container.querySelector<HTMLElement>('.test-card')
+    expect(card).toBeTruthy()
+
+    fireEvent.auxClick(card!, { button: 2 })
+    fireEvent.auxClick(card!, { button: 1 })
+
+    expect(onClick).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/ui/__tests__/spotlight-card.test.tsx
+++ b/src/components/ui/__tests__/spotlight-card.test.tsx
@@ -9,12 +9,6 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-function getCard(container: HTMLElement) {
-  const card = container.querySelector<HTMLElement>('[data-test-card]')
-  if (!card) throw new Error('SpotlightCard was not rendered')
-  return card
-}
-
 describe('SpotlightCard middle click', () => {
   it('runs the bookmark action on middle click and keeps focus on the current page', () => {
     const onClick = vi.fn()

--- a/src/components/ui/spotlight-card.tsx
+++ b/src/components/ui/spotlight-card.tsx
@@ -10,6 +10,29 @@ interface SpotlightCardProps {
   lightweight?: boolean // 轻量模式：禁用 spotlight/border beam，用纯 CSS hover 代替 framer-motion
   onClick?: () => void
   onContextMenu?: (e: React.MouseEvent) => void
+  /**
+   * 是否让鼠标中键执行卡片主操作。
+   * 书签卡片都会提供右键菜单，因此默认在存在 onContextMenu 时启用；
+   * 其他类型的可点击卡片可显式开启或关闭。
+   */
+  openOnMiddleClick?: boolean
+}
+
+const INTERACTIVE_DESCENDANT_SELECTOR = [
+  'a',
+  'button',
+  'input',
+  'textarea',
+  'select',
+  '[role="button"]',
+  '[contenteditable="true"]',
+].join(',')
+
+function isInteractiveDescendant(event: React.MouseEvent<HTMLDivElement>) {
+  const target = event.target
+  return target instanceof Element && target !== event.currentTarget
+    ? Boolean(target.closest(INTERACTIVE_DESCENDANT_SELECTOR))
+    : false
 }
 
 /**
@@ -26,6 +49,7 @@ export function SpotlightCard({
   lightweight = false,
   onClick,
   onContextMenu,
+  openOnMiddleClick = Boolean(onContextMenu),
 }: SpotlightCardProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const rafIdRef = useRef<number>(0)
@@ -58,6 +82,40 @@ export function SpotlightCard({
     setIsHovered(false)
   }, [])
 
+  // 中键按下时阻止浏览器进入自动滚屏模式，但不影响卡片内按钮等独立控件。
+  const handleMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      event.button === 1 &&
+      openOnMiddleClick &&
+      onClick &&
+      !isInteractiveDescendant(event)
+    ) {
+      event.preventDefault()
+    }
+  }, [onClick, openOnMiddleClick])
+
+  // auxclick 专门处理非主鼠标键；button === 1 表示中键。
+  const handleAuxClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    if (
+      event.button !== 1 ||
+      !openOnMiddleClick ||
+      !onClick ||
+      isInteractiveDescendant(event)
+    ) {
+      return
+    }
+
+    event.preventDefault()
+    onClick()
+
+    // 卡片主操作会通过 window.open 打开书签；重新聚焦当前页，保持“后台打开”体验。
+    try {
+      window.focus()
+    } catch {
+      // 某些 WebView 不允许脚本主动聚焦，打开行为本身仍然有效。
+    }
+  }, [onClick, openOnMiddleClick])
+
   // 清理 RAF
   useEffect(() => {
     return () => cancelAnimationFrame(rafIdRef.current)
@@ -74,6 +132,8 @@ export function SpotlightCard({
   if (lightweight) {
     return (
       <div
+        onMouseDown={handleMouseDown}
+        onAuxClick={handleAuxClick}
         onClick={onClick}
         onContextMenu={onContextMenu}
         className={cn(
@@ -100,6 +160,8 @@ export function SpotlightCard({
       onMouseMove={handleMouseMove}
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
+      onMouseDown={handleMouseDown}
+      onAuxClick={handleAuxClick}
       onClick={onClick}
       onContextMenu={onContextMenu}
       className={cn(


### PR DESCRIPTION
## 需求分析

Closes #11

当前首页书签卡片由 `div + onClick + window.open` 实现。鼠标中键不会触发普通 `click`，而是触发 `auxclick`，因此现有卡片完全没有响应；同时中键按下还可能触发浏览器自动滚屏。

用户需要在一次打开多个书签时，保持 NOWEN 当前页面不切走，通过中键连续把书签放到后台页签中。

## 实现

- 在 `SpotlightCard` 中识别 `auxclick` 的 `button === 1`
- 复用现有卡片主操作，因此继续执行访问统计、内外网 URL 转换及打开逻辑
- 打开后重新聚焦当前窗口，保持后台打开体验
- 在中键 `mousedown` 阶段阻止浏览器自动滚屏
- 自动跳过卡片内的按钮、链接、输入框、`role=button` 和可编辑区域，避免中键点击“置顶/编辑/删除/标签”等控件时误开书签
- 仅对书签类卡片默认启用：当前以存在右键菜单作为默认判定；其他卡片可通过 `openOnMiddleClick` 显式控制
- 日间/夜间、普通动画模式和轻量模式共用同一行为

## 验证

新增组件测试覆盖：

- 中键触发卡片主操作
- 中键按下阻止自动滚屏
- 中键点击嵌套操作按钮不触发卡片
- 右键不触发
- 可显式关闭中键行为

## 兼容性

不修改左键、右键菜单、拖拽排序和移动端触摸行为。