### PR TITLE
fix(ui): make middle-click work across full bookmark card

### DIFF
--- a/src/components/ui/__tests__/spotlight-card.test.tsx
+++ b/src/components/ui/__tests__/spotlight-card.test.tsx
@@ -49,6 +49,31 @@ describe('SpotlightCard middle click', () => {
     expect(fireEvent.mouseDown(card!, { button: 1 })).toBe(false)
   })
 
+  it.each([false, true])(
+    'opens from card content even when the sortable ancestor has role=button (lightweight=%s)',
+    (lightweight) => {
+      const onClick = vi.fn()
+      const { getByText } = render(
+        <div role="button" aria-label="Sortable bookmark">
+          <SpotlightCard
+            lightweight={lightweight}
+            onClick={onClick}
+            onContextMenu={() => undefined}
+          >
+            <div>
+              <span>Bookmark title</span>
+              <p>Bookmark description</p>
+            </div>
+          </SpotlightCard>
+        </div>,
+      )
+
+      fireEvent.auxClick(getByText('Bookmark title'), { button: 1 })
+
+      expect(onClick).toHaveBeenCalledTimes(1)
+    },
+  )
+
   it('does not open the bookmark when middle-clicking a nested action', () => {
     const onClick = vi.fn()
     const { getByRole } = render(

--- a/src/components/ui/spotlight-card.tsx
+++ b/src/components/ui/spotlight-card.tsx
@@ -30,9 +30,19 @@ const INTERACTIVE_DESCENDANT_SELECTOR = [
 
 function isInteractiveDescendant(event: React.MouseEvent<HTMLDivElement>) {
   const target = event.target
-  return target instanceof Element && target !== event.currentTarget
-    ? Boolean(target.closest(INTERACTIVE_DESCENDANT_SELECTOR))
-    : false
+  if (!(target instanceof Element) || target === event.currentTarget) {
+    return false
+  }
+
+  const interactiveElement = target.closest(INTERACTIVE_DESCENDANT_SELECTOR)
+
+  // closest() 会继续向卡片外层查找。书签外层的 dnd-kit SortableCard
+  // 会被标记为 role="button"，不能把它误判为卡片内部的操作按钮。
+  return Boolean(
+    interactiveElement &&
+    interactiveElement !== event.currentTarget &&
+    event.currentTarget.contains(interactiveElement),
+  )
 }
 
 /**


### PR DESCRIPTION
## 问题复现

Follow-up for #11.

上一版为了避免中键点击置顶、编辑、删除、标签等内部控件时误开书签，使用了 `target.closest('[role="button"]')` 判断交互区域。

但首页书签外层由 `dnd-kit` 的 `SortableCard` 包裹，该外层容器本身会被标记为 `role="button"`。`closest()` 会越过当前 `SpotlightCard` 继续向外查找，于是卡片正文、标题、描述等区域都被误判为“交互按钮”，只有少量没有命中该祖先判断的边缘区域偶尔可用。紧凑、标准、宽松三种视图共用同一组件，因此表现一致。

## 修复

- 交互元素判断增加当前卡片边界限制
- 只有真正位于 `SpotlightCard` 内部的按钮、链接、输入框等控件才会拦截中键
- 卡片外层 `SortableCard[role=button]` 不再参与内部控件判断
- 保留置顶、稍后阅读、编辑、删除、标签等按钮的防误触逻辑
- 普通动画模式和轻量模式同时生效，三种书签视图无需分别打补丁

## 回归测试

新增测试模拟真实结构：

```text
SortableCard[role=button]
└── SpotlightCard
    └── 标题 / 描述
```

分别验证普通模式与轻量模式下，中键点击标题均能触发卡片主操作；原有内部按钮不误触测试继续保留。

Closes #11